### PR TITLE
Fixed event handling for multiple sdl windows.

### DIFF
--- a/include/canyon.h
+++ b/include/canyon.h
@@ -13,6 +13,7 @@
 #include <array>
 #include <cassert>
 #include <fstream>
+#include <list>
 
 #include <vulkan/vulkan.hpp>
 #include <vk_mem_alloc.h>

--- a/include/events/event_emitter.h
+++ b/include/events/event_emitter.h
@@ -10,7 +10,7 @@ class LambdaWrapper : public moth_ui::EventListener {
             :m_lambda(lambda) {
             }
 
-        bool OnEvent(moth_ui::Event const& event) {
+        bool OnEvent(moth_ui::Event const& event) override {
             return m_lambda(event);
         }
 

--- a/include/layers/layer_stack.h
+++ b/include/layers/layer_stack.h
@@ -6,7 +6,7 @@
 
 class Layer;
 
-class LayerStack : public EventEmitter, public moth_ui::EventListener {
+class LayerStack : public moth_ui::EventListener {
 public:
     LayerStack(int renderWidth, int renderHeight, int windowWidth, int windowHeight);
     virtual ~LayerStack();

--- a/include/platform/sdl/sdl_window.h
+++ b/include/platform/sdl/sdl_window.h
@@ -27,6 +27,7 @@ namespace platform::sdl {
         graphics::sdl::Context& m_context;
         std::unique_ptr<graphics::sdl::SurfaceContext> m_surfaceContext;
 
+        uint32_t m_windowId = 0;
         SDL_Window* m_window = nullptr;
         SDL_Renderer* m_renderer = nullptr;
 

--- a/src/platform/application.cpp
+++ b/src/platform/application.cpp
@@ -7,7 +7,6 @@ Application::Application(platform::IPlatform& platform)
 
     m_window = m_platform.CreateWindow("testing", 640, 480);
     m_window->AddEventListener(this);
-    m_window->GetLayerStack().AddEventListener(this);
     
 }
 


### PR DESCRIPTION
Created a new function that collects all SDL events into a local buffer that is then iterated over to find the first event matching the given window id. If one is found it's returned in the out parameter and the function succeeds. If none is found then it returns false.