### PR TITLE
Adding back imgui image rendering.

### DIFF
--- a/include/canyon/graphics/iimage.h
+++ b/include/canyon/graphics/iimage.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "canyon/utils/vector.h"
+
 namespace canyon::graphics {
     class IImage {
     public:
@@ -7,5 +9,7 @@ namespace canyon::graphics {
 
         virtual int GetWidth() const = 0;
         virtual int GetHeight() const = 0;
+
+        virtual void ImGui(canyon::IntVec2 const& size, canyon::FloatVec2 const& uv0 = { 0, 0 }, canyon::FloatVec2 const& uv1 = { 1, 1 }) const = 0;
     };
 }

--- a/include/canyon/graphics/sdl/sdl_image.h
+++ b/include/canyon/graphics/sdl/sdl_image.h
@@ -18,6 +18,8 @@ namespace canyon::graphics::sdl {
         int GetWidth() const override;
         int GetHeight() const override;
 
+        void ImGui(canyon::IntVec2 const& size, canyon::FloatVec2 const& uv0 = { 0, 0 }, canyon::FloatVec2 const& uv1 = { 1, 1 }) const override;
+
         std::shared_ptr<Texture> GetTexture() const {
             return m_texture;
         }

--- a/include/canyon/graphics/vulkan/vulkan_framebuffer.h
+++ b/include/canyon/graphics/vulkan/vulkan_framebuffer.h
@@ -27,6 +27,8 @@ namespace canyon::graphics::vulkan {
         int GetWidth() const override { return m_image ? m_image->GetWidth() : 0; }
         int GetHeight() const override { return m_image ? m_image->GetHeight() : 0; }
 
+        void ImGui(canyon::IntVec2 const& size, canyon::FloatVec2 const& uv0 = { 0, 0 }, canyon::FloatVec2 const& uv1 = { 1, 1 }) const override;
+
         VkFramebuffer GetVkFramebuffer() const { return m_vkFramebuffer; }
         CommandBuffer& GetCommandBuffer() { return *m_commandBuffer; }
         Fence& GetFence() const { return *m_fence; }

--- a/include/canyon/graphics/vulkan/vulkan_image.h
+++ b/include/canyon/graphics/vulkan/vulkan_image.h
@@ -18,11 +18,11 @@ namespace canyon::graphics::vulkan {
         int GetWidth() const override;
         int GetHeight() const override;
 
+        void ImGui(canyon::IntVec2 const& size, canyon::FloatVec2 const& uv0 = { 0, 0 }, canyon::FloatVec2 const& uv1 = { 1, 1 }) const override;
+
         static std::unique_ptr<Image> Load(SurfaceContext& context, std::filesystem::path const& path);
 
         std::shared_ptr<Texture> m_texture;
         IntRect m_sourceRect;
-
-        static class Graphics* s_graphicsContext;
     };
 }

--- a/src/graphics/sdl/sdl_image.cpp
+++ b/src/graphics/sdl/sdl_image.cpp
@@ -21,6 +21,13 @@ namespace canyon::graphics::sdl {
         return m_sourceRect.bottomRight.y - m_sourceRect.topLeft.y;
     }
 
+    void Image::ImGui(canyon::IntVec2 const& size, canyon::FloatVec2 const& uv0, canyon::FloatVec2 const& uv1) const {
+        ImGui::Image(m_texture ? m_texture->GetSDLTexture()->GetImpl() : nullptr,
+                     ImVec2(static_cast<float>(size.x), static_cast<float>(size.y)),
+                     ImVec2(uv0.x, uv0.y),
+                     ImVec2(uv1.x, uv1.y));
+    }
+
     std::unique_ptr<Image> Image::Load(SurfaceContext& context, std::filesystem::path const& path) {
         if (auto texture = Texture::FromFile(context.GetRenderer(), path)) {
             auto sdlTexture = std::unique_ptr<Texture>(static_cast<Texture*>(texture.release()));

--- a/src/graphics/vulkan/vulkan_context.cpp
+++ b/src/graphics/vulkan/vulkan_context.cpp
@@ -24,7 +24,7 @@ namespace {
         void* pUserData) {
         switch (messageSeverity) {
         case VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT:
-            // spdlog::info("Validation Layer: {}", pCallbackData->pMessage);
+            spdlog::info("Validation Layer: {}", pCallbackData->pMessage);
             break;
         case VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT:
             spdlog::info("Validation Layer: {}", pCallbackData->pMessage);

--- a/src/graphics/vulkan/vulkan_framebuffer.cpp
+++ b/src/graphics/vulkan/vulkan_framebuffer.cpp
@@ -42,6 +42,12 @@ namespace canyon::graphics::vulkan {
         vkDestroyFramebuffer(m_context.GetVkDevice(), m_vkFramebuffer, nullptr);
     }
 
+    void Framebuffer::ImGui(canyon::IntVec2 const& size, canyon::FloatVec2 const& uv0, canyon::FloatVec2 const& uv1) const {
+        if (m_image) {
+            m_image->ImGui(size, uv0, uv1);
+        }
+    }
+
     VkExtent2D Framebuffer::GetVkExtent() const {
         return m_image->m_texture->GetVkExtent();
     }

--- a/src/graphics/vulkan/vulkan_graphics.cpp
+++ b/src/graphics/vulkan/vulkan_graphics.cpp
@@ -530,7 +530,8 @@ namespace canyon::graphics::vulkan {
         }
 
         if (target) {
-            m_overrideContext.m_target = static_cast<Framebuffer*>(target);
+            m_overrideContext.m_target = dynamic_cast<Framebuffer*>(target);
+            assert(m_overrideContext.m_target);
             VkFence fence = m_overrideContext.m_target->GetFence().GetVkFence();
             vkResetFences(m_context.GetVkDevice(), 1, &fence);
             BeginContext(&m_overrideContext);

--- a/src/graphics/vulkan/vulkan_image.cpp
+++ b/src/graphics/vulkan/vulkan_image.cpp
@@ -3,8 +3,6 @@
 #include "canyon/graphics/vulkan/vulkan_graphics.h"
 
 namespace canyon::graphics::vulkan {
-    Graphics* Image::s_graphicsContext = nullptr;
-
     Image::Image(std::shared_ptr<Texture> texture)
     : m_texture(texture) 
     , m_sourceRect({{ 0, 0 }, { texture->GetWidth(), texture->GetHeight() }}) {
@@ -25,6 +23,16 @@ namespace canyon::graphics::vulkan {
 
     int Image::GetHeight() const {
         return m_sourceRect.bottomRight.y - m_sourceRect.topLeft.y;
+    }
+
+
+    void Image::ImGui(canyon::IntVec2 const& size, canyon::FloatVec2 const& uv0, canyon::FloatVec2 const& uv1) const {
+        if (m_texture) {
+            ImGui::Image(m_texture->GetDescriptorSet(),
+                            ImVec2(static_cast<float>(size.x), static_cast<float>(size.y)),
+                            ImVec2(uv0.x, uv0.y),
+                            ImVec2(uv1.x, uv1.y));
+        }
     }
 
     std::unique_ptr<Image> Image::Load(SurfaceContext& context, std::filesystem::path const& path) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added ImGui rendering support for images and framebuffers, allowing them to be displayed directly in the user interface with customizable size and texture region.
- **Bug Fixes**
	- Improved type safety and reliability when setting Vulkan framebuffer targets.
- **Chores**
	- Enabled verbose Vulkan validation layer logging for enhanced debugging.
- **Refactor**
	- Removed an unused static graphics context member from the Vulkan image implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->