### PR TITLE
fix: Vulkan synchronization and shutdown correctness

### DIFF
--- a/include/canyon/graphics/vulkan/vulkan_swapchain.h
+++ b/include/canyon/graphics/vulkan/vulkan_swapchain.h
@@ -14,6 +14,7 @@ namespace canyon::graphics::vulkan {
     struct FrameSlot {
         VkSemaphore imageAvailable;
         VkSemaphore renderFinished;
+        uint32_t lastImageIndex = UINT32_MAX;
     };
 
     class Swapchain {

--- a/src/graphics/vulkan/vulkan_graphics.cpp
+++ b/src/graphics/vulkan/vulkan_graphics.cpp
@@ -99,11 +99,7 @@ namespace canyon::graphics::vulkan {
     }
 
     Graphics::~Graphics() {
-        if (!m_contextStack.empty()) {
-            auto context = m_contextStack.top();
-            auto cmdFence = context->m_target->GetFence().GetVkFence();
-            vkWaitForFences(m_surfaceContext.GetVkDevice(), 1, &cmdFence, VK_TRUE, UINT64_MAX);
-        }
+        vkDeviceWaitIdle(m_surfaceContext.GetVkDevice());
 
         if (m_imguiInitialized) {
             ImGui_ImplVulkan_Shutdown();
@@ -169,7 +165,6 @@ namespace canyon::graphics::vulkan {
 
         m_defaultContext.m_target = m_swapchain->GetNextFramebuffer();
         VkFence cmdFence = m_defaultContext.m_target->GetFence().GetVkFence();
-        vkWaitForFences(m_surfaceContext.GetVkDevice(), 1, &cmdFence, VK_TRUE, UINT64_MAX);
         vkResetFences(m_surfaceContext.GetVkDevice(), 1, &cmdFence);
 
         BeginContext(&m_defaultContext);
@@ -542,6 +537,7 @@ namespace canyon::graphics::vulkan {
             m_overrideContext.m_target = dynamic_cast<Framebuffer*>(target);
             assert(m_overrideContext.m_target);
             VkFence fence = m_overrideContext.m_target->GetFence().GetVkFence();
+            vkWaitForFences(m_surfaceContext.GetVkDevice(), 1, &fence, VK_TRUE, UINT64_MAX);
             vkResetFences(m_surfaceContext.GetVkDevice(), 1, &fence);
             BeginContext(&m_overrideContext);
         }
@@ -577,7 +573,7 @@ namespace canyon::graphics::vulkan {
         switch (mode) {
         default:
         case BlendMode::Replace:
-            currentBlend.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT;
+            currentBlend.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
             currentBlend.blendEnable = VK_FALSE;
             currentBlend.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
             currentBlend.dstColorBlendFactor = VK_BLEND_FACTOR_ZERO;

--- a/src/graphics/vulkan/vulkan_swapchain.cpp
+++ b/src/graphics/vulkan/vulkan_swapchain.cpp
@@ -107,12 +107,29 @@ namespace canyon::graphics::vulkan {
     Framebuffer* Swapchain::GetNextFramebuffer() {
         auto& slot = m_frames[m_currentFrame];
 
+        // Wait for the framebuffer this slot previously submitted to.
+        // This guarantees slot->imageAvailable has no pending operations
+        // from its last use as a wait semaphore in vkQueueSubmit.
+        if (slot->lastImageIndex != UINT32_MAX) {
+            VkFence prevFence = m_framebuffers[slot->lastImageIndex]->GetFence().GetVkFence();
+            vkWaitForFences(m_context.GetVkDevice(), 1, &prevFence, VK_TRUE, UINT64_MAX);
+        }
+
         uint32_t imageIndex;
         VkResult result = vkAcquireNextImageKHR(m_context.GetVkDevice(), m_vkSwapchain, UINT64_MAX, slot->imageAvailable, VK_NULL_HANDLE, &imageIndex);
         if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
             return nullptr;
         }
         CHECK_VK_RESULT(result);
+
+        // If the acquired image differs from this slot's last image, also wait on
+        // the acquired image's fence so its command buffer is safe to reuse.
+        if (imageIndex != slot->lastImageIndex) {
+            VkFence imageFence = m_framebuffers[imageIndex]->GetFence().GetVkFence();
+            vkWaitForFences(m_context.GetVkDevice(), 1, &imageFence, VK_TRUE, UINT64_MAX);
+        }
+
+        slot->lastImageIndex = imageIndex;
         m_framebuffers[imageIndex]->SetFrameSlot(slot);
         m_currentFrame = (m_currentFrame + 1) % m_framebuffers.size();
         return m_framebuffers[imageIndex].get();

--- a/src/platform/glfw/glfw_window.cpp
+++ b/src/platform/glfw/glfw_window.cpp
@@ -116,11 +116,19 @@ namespace canyon::platform::glfw {
     }
 
     void Window::DestroyWindow() {
+        // Wait for all GPU work to finish before destroying Vulkan-backed resources
+        if (m_surfaceContext) {
+            vkDeviceWaitIdle(m_surfaceContext->GetVkDevice());
+        }
         PreDestroy();
         // TODO: why do we do this in destroy?
         m_windowMaximized = glfwGetWindowAttrib(m_glfwWindow, GLFW_MAXIMIZED) == GLFW_TRUE;
         m_graphics = nullptr;
         m_surfaceContext = nullptr;
+        if (m_customVkSurface != VK_NULL_HANDLE) {
+            vkDestroySurfaceKHR(m_context.GetInstance(), m_customVkSurface, nullptr);
+            m_customVkSurface = VK_NULL_HANDLE;
+        }
         glfwDestroyWindow(m_glfwWindow);
     }
 


### PR DESCRIPTION
- SetTarget(): wait on fence before reset to avoid resetting an in-use fence
- GetNextFramebuffer(): track lastImageIndex per FrameSlot so the correct fence is waited on before vkAcquireNextImageKHR, preventing semaphore pending-operation errors when slot and image indices diverge
- Begin(): remove redundant fence wait (now handled in GetNextFramebuffer)
- BlendMode::Replace: add VK_COLOR_COMPONENT_A_BIT to colorWriteMask so the alpha channel is written to offscreen render targets, fixing the hall-of-mirrors effect when ImGui samples the canvas texture
- Graphics::~Graphics(): replace selective fence wait with vkDeviceWaitIdle
- DestroyWindow(): call vkDeviceWaitIdle before PreDestroy() so GPU work completes before Vulkan-backed resources (samplers, buffers, images) are freed; destroy VkSurfaceKHR explicitly to eliminate the validation leak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vulkan graphics rendering synchronization to ensure safe and efficient reuse of frame resources across consecutive frames
  * Enhanced window destruction cleanup procedures for graphics contexts and surfaces to prevent resource leaks
  * Fixed alpha channel handling in color write operations for more accurate rendering results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->