### PR TITLE
fix: Remove FreeType headers from public canyon headers

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -94,12 +94,12 @@ class canyon(ConanFile):
             else:
                 try:
                     flags = subprocess.check_output(
-                        [pkg_config, "--cflags-only-I", "sdl2"],
+                        [pkg_config, "--cflags-only-I", "sdl2", "freetype2", "harfbuzz"],
                         text=True
                     ).split()
                     for flag in flags:
                         if flag.startswith("-I"):
                             self.cpp_info.includedirs.append(flag[2:])
                 except subprocess.SubprocessError as e:
-                    self.output.warning(f"pkg-config query failed; SDL2 include path not automatically propagated to consumers: {e}")
+                    self.output.warning(f"pkg-config query failed; system library include paths not automatically propagated to consumers: {e}")
 

--- a/include/canyon/graphics/vulkan/vulkan_context.h
+++ b/include/canyon/graphics/vulkan/vulkan_context.h
@@ -3,8 +3,11 @@
 #include "canyon/graphics/context.h"
 
 #include <vulkan/vulkan_core.h>
-#include <ft2build.h>
-#include FT_FREETYPE_H
+
+// Forward-declare FT_Library to avoid requiring FreeType headers in consumers.
+// FT_Library is typedef struct FT_LibraryRec_ *FT_Library in freetype/freetype.h.
+struct FT_LibraryRec_;
+typedef FT_LibraryRec_* FT_Library;
 
 namespace canyon::graphics::vulkan {
     class Context : public canyon::graphics::Context {

--- a/include/canyon/graphics/vulkan/vulkan_font.h
+++ b/include/canyon/graphics/vulkan/vulkan_font.h
@@ -10,6 +10,11 @@
 #include <harfbuzz/hb.h>
 #include <vulkan/vulkan_core.h>
 
+// Forward-declare FT_Face to avoid requiring FreeType headers in consumers.
+// FT_Face is typedef struct FT_FaceRec_ *FT_Face in freetype/freetype.h.
+struct FT_FaceRec_;
+typedef FT_FaceRec_* FT_Face;
+
 #include <cstdint>
 #include <filesystem>
 #include <map>

--- a/src/graphics/vulkan/vulkan_context.cpp
+++ b/src/graphics/vulkan/vulkan_context.cpp
@@ -1,5 +1,7 @@
 #include "common.h"
 #include "canyon/graphics/vulkan/vulkan_context.h"
+#include <ft2build.h>
+#include FT_FREETYPE_H
 #include "canyon/graphics/vulkan/vulkan_utils.h"
 
 #include <spdlog/spdlog.h>

--- a/src/graphics/vulkan/vulkan_font.cpp
+++ b/src/graphics/vulkan/vulkan_font.cpp
@@ -1,4 +1,6 @@
 #include "common.h"
+#include <ft2build.h>
+#include FT_FREETYPE_H
 #include "canyon/graphics/vulkan/vulkan_font.h"
 #include "canyon/graphics/stb_rect_pack.h"
 #include "canyon/graphics/vulkan/vulkan_utils.h"


### PR DESCRIPTION
vulkan_context.h and vulkan_font.h are public headers that canyon consumers include transitively. They were pulling in <ft2build.h> which lives in /usr/include/freetype2/ — a non-default search path — forcing all consumers (e.g. TinCan) to have that directory in their include path even though they don't use FreeType directly.

Replace the FreeType #includes with forward declarations of FT_LibraryRec_/FT_Library and FT_FaceRec_/FT_Face, and move the actual FreeType includes into the .cpp files that need them.

Also extend the pkg-config query in conanfile.py package_info() to include freetype2 and harfbuzz alongside sdl2 (redundant now but correct for completeness).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized graphics library dependencies to enhance build performance.
  * Reorganized internal header structure for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->