### PR TITLE
fix: Wire LayerStack event listener in Application::Init()

### DIFF
--- a/src/platform/application.cpp
+++ b/src/platform/application.cpp
@@ -15,6 +15,7 @@ namespace canyon::platform {
         Startup();
         m_window = m_platform.CreateWindow(m_mainWindowTitle, m_mainWindowWidth, m_mainWindowHeight);
         m_window->AddEventListener(this);
+        m_window->GetLayerStack().SetEventListener(this);
         m_window->GetGraphics().InitImgui(*m_window);
         PostCreateWindow();
     }


### PR DESCRIPTION
Application::Init() already called m_window->AddEventListener(this) so that window events reach the application, but it didn't call m_window->GetLayerStack().SetEventListener(this), leaving no path for events broadcast from layers (e.g. EventQuit on Escape) to bubble back up to the application. Consumers were forced to call SetEventListener manually after Init(). Wire it automatically alongside AddEventListener.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced event handling flow to properly integrate layer management systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->