### PR TITLE
fix: Use libfreetype-dev apt package name for Ubuntu 24.04+

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -48,10 +48,10 @@ class canyon(ConanFile):
                 raise ConanInvalidConfiguration(
                     "apt-get is required to install system SDL2/GLFW/FreeType/HarfBuzz libraries on Linux. "
                     "On non-Debian/Ubuntu systems, install libsdl2-dev, libsdl2-image-dev, "
-                    "libsdl2-ttf-dev, libglfw3-dev, libfreetype6-dev, and libharfbuzz-dev manually via your system package manager."
+                    "libsdl2-ttf-dev, libglfw3-dev, libfreetype-dev, and libharfbuzz-dev manually via your system package manager."
                 )
             apt = Apt(self)
-            apt.install(["libsdl2-dev", "libsdl2-image-dev", "libsdl2-ttf-dev", "libglfw3-dev", "libfreetype6-dev", "libharfbuzz-dev"])
+            apt.install(["libsdl2-dev", "libsdl2-image-dev", "libsdl2-ttf-dev", "libglfw3-dev", "libfreetype-dev", "libharfbuzz-dev"])
 
     def build_requirements(self):
         self.tool_requires("cmake/3.27.0")


### PR DESCRIPTION
libfreetype6-dev was renamed to libfreetype-dev in Ubuntu 24.04. Update both the apt.install() call and the error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system package dependency: Changed the required Linux freetype library package from libfreetype6-dev to libfreetype-dev. Related error messages and installation documentation have been updated to reflect the new package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->