### PR TITLE
chore: add git-cliff changelog automation and expand TODO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+# Triggered when upload-lib.yml tags the repo with the version from version.txt
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0       # full history required for git-cliff
+          ref: master          # check out master so we can commit back to it
+
+      - name: Generate CHANGELOG.md
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --verbose
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Commit CHANGELOG.md to master
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet || git commit -m "chore(release): update CHANGELOG.md for ${{ github.ref_name }}"
+          git push origin master
+
+      - name: Generate release notes (current version only)
+        id: release-notes
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --verbose --current --strip header
+        env:
+          OUTPUT: RELEASE_NOTES.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: RELEASE_NOTES.md
+          tag_name: ${{ github.ref_name }}
+          name: "canyon ${{ github.ref_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,103 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+Entries are generated automatically from git history using [git-cliff](https://github.com/orhun/git-cliff).
+
+## [Unreleased]
+### Bug Fixes
+- Vulkan synchronization and shutdown correctness
+- Remove FreeType headers from public canyon headers
+- Wire LayerStack event listener in Application::Init()
+- Use libfreetype-dev apt package name for Ubuntu 24.04+
+
+### Changes
+- Decoupling the available semaphore from the swapchain image.
+- Frame-slot
+- Updates from moth_ui release. Bringing into better state.
+
+## [0.3.0] - 2025-08-14
+### Changes
+- Aliasing moth ui types instead of duplicating and converting.
+
+## [0.2.0] - 2025-05-10
+### Bug Fixes
+- Fix: Fixed font loading for moth font factory.
+- Fix: Fixed the incorrect rendering of images in vulkan.
+- Fixed sdl font rendering
+- Fixed font rendering on vulkan
+- SDL rendering with multiple windows
+- Vulkan tiled rendering.
+- Fixing windows builds.
+- Updating some header exposures
+- Fixing upload action
+
+### Changes
+- Added SDL and GLFW abstractions to creating a window. Will be changing how this works soon
+- Adding in sdl graphics wrappings
+- Just switching for testing
+- Ignoring warnings in fontcache
+- Fixing up some ordering. Not happy with the current setup but it works for now
+- Simplifying things
+- Added vulkan work
+- Some stuff
+- Working glfw and sdl implementations
+- Moving away from inheritence chains
+- Adding event_emitter
+- Adding precompiled header. Cleaned up main
+- Fixing vulkan resize, Adding layers to test applications
+- Well it's building
+- Building and running (SDL)
+- Removing unused font factory header
+- Fixing up vulkan
+- Moving graphics and layer stacks into window which seems more appropriate
+- Added loading methods for image and font
+- Cleaning up a little bit
+- More cleanup. glfw events was duplicated in vulkan events. Moving some source around
+- WIP commit so i can swap OSes
+- Working with SDL and Vulkan.
+- Making platform independent developing easier
+- So much stuff... Separating out graphics stuff and moth_ui stuff still
+- Fixed event handling for multiple sdl windows.
+- Turning canyon into more of a consumable library.
+- Imgui implementation.
+- ITargets are now IImages.
+- Fixing ITarget usage.
+- Cleaning up building and packaging.
+- Adding actions to build and upload artifacts.
+- Updates for moth_ui api change.
+
+### Features
+- Updated moth renderer to have logical size support.
+- Adding back imgui image rendering
+
+### Miscellaneous
+- Updated build file list
+- Updated notes
+- Chore(cleanup): Deleting unneeded files.
+- Misc things before refactor.
+- Making compile define private
+
+### Refactoring
+- Refactor(font_factory): Adding new moth font factory.
+- Refactor(font_factory): Removing api specific font factories.
+- Refactor(font_factory): Internal implementation of font factory.
+- Refactor(image_factory): Moth image factory now just a wrapper.
+- Refactor(factories): Removed old implementation specific factories.
+- Refactor(moth_ui/wrapper): Unified ui_renderer
+- Refactor(graphics/utilities): Cleaning up some utility conversions.
+- Refactor(graphics/vulkan): Misc vulkan cleanups.
+- Refactor(platform): Cleaning up platform, application, window layout.
+- Refactor(main): SDL portion working.
+- Refactor(font/vulkan): Font no longer needs graphics.
+- Refactor(graphics): Moving asset loading out of graphics.
+- Renamed ui_renerer to MothRenderer
+- Small adjustments to how events are defined
+- Added graphics contexts to windows.
+- The moth context is now passed into the ui node tree.
+- Just some formatting stuff and minor cleanups.
+- Moved example code into its own location
+- Moved the button widget
+- Added an example main function that draws two windows
+- Removed canyon layers in favor of moth_ui layers.
+
+

--- a/TODO.md
+++ b/TODO.md
@@ -27,9 +27,96 @@ logged and dropped. The limit needs to be removed. Three options:
 
 ---
 
-## Architectural / Known Issues (from NOTES.md)
+## SDL Multi-Window Input Routing
 
-- **Vulkan crashes on window close** unless all resources (images, fonts) linked to that context are destroyed first. Resources need to be per-window; assets created for one window will not work on another.
-- **Vulkan exit cleanup crashes** — needs investigation.
-- **SDL multi-window event handling** not yet properly implemented.
-- **`SurfaceContext`** design could be improved — see NOTES.md for planned refactor.
+Input events (keyboard, mouse, etc.) are collected via a shared static
+`PendingEvents` list in `sdl_window.cpp`. Each call to
+`CollectSDLEventsForWindow()` polls SDL, dumps everything into the shared list,
+then extracts events matching the calling window's ID and removes them.
+
+The problem: input events have `windowID == 0` (or the focused window's ID) and
+are matched and removed by whichever window calls `Update()` first. In a
+multi-window setup the second window never sees keyboard/mouse input.
+
+Proposed fix: route input events to the window that currently has SDL focus.
+`SDL_GetKeyboardFocus()` and `SDL_GetMouseFocus()` return the focused
+`SDL_Window*`; use `SDL_GetWindowID()` on that to resolve the correct target
+before dispatching. Alternatively, deliver input events to all windows and let
+each decide relevance — consistent with how most windowing systems broadcast
+input to the foreground window only.
+
+---
+
+## SurfaceContext Design
+
+The current split — `Context` (application-wide, holds Vulkan instance / SDL
+init) and `SurfaceContext` (per-window, holds renderer, pools, allocators) — is
+mostly right but the boundary is fuzzy. The factories (`ImageFactory`,
+`FontFactory`) live on `SurfaceContext`, which is correct because assets are
+window-bound, but consumers sometimes reach through to `GetContext()` to get
+application-wide resources.
+
+From NOTES (29/03/25): the intent was `Context` = application context,
+`SurfaceContext` = surface/window context, and an `AssetLoader` that comes from
+`SurfaceContext` for disk I/O. The asset-loading methods (`ImageFromFile`,
+`FontFromFile`, `TextureFromFile`) currently live directly on `SurfaceContext`
+rather than on a dedicated loader type.
+
+Options:
+- **Option A — Keep current shape, clarify the interface**: Document that
+  `SurfaceContext` is intentionally the asset entry point; remove
+  `GetContext()` from the public API so callers can't reach through.
+- **Option B — Extract `AssetLoader`**: `SurfaceContext` becomes purely about
+  GPU resource lifetime; a separate `AssetLoader` (obtained from
+  `SurfaceContext`) handles file I/O and caching. Cleaner separation but more
+  surface area.
+
+---
+
+## Test Suite
+
+There are no automated tests. The example app exercises the library manually but
+is not a regression harness. Without tests it is difficult to verify correctness
+across backends or catch regressions when making changes.
+
+Suggested scope for a 1.0 test suite:
+
+- **Smoke tests**: platform startup/shutdown, window creation and destruction,
+  basic draw calls through both backends without crashing.
+- **Asset loading**: texture and font load from file; verify dimensions/metrics
+  are as expected.
+- **Layer stack**: push/pop layers, verify update and draw ordering.
+- **Event routing**: emit window events, verify listeners receive them; verify
+  `SDL_QUIT` propagates correctly.
+
+A lightweight framework (Catch2 or GoogleTest) can be added as a Conan dev
+dependency without affecting the shipped package. Backends that require a
+display can be guarded with a CMake option for headless CI.
+
+---
+
+## Precompiled Headers
+
+`CMakeLists.txt` line 213 has the PCH target commented out:
+
+```cmake
+# temp disabled while i figure out other build issues. it is intended to use precompiled headers eventually
+# target_precompile_headers(${PROJECT_NAME} PRIVATE include/canyon.h)
+```
+
+Either resolve the build issue and re-enable it, or remove the comment if PCH
+is no longer planned. Leaving dead commented-out build code in CMakeLists
+creates ambiguity about intent.
+
+---
+
+## Documentation
+
+- **CHANGELOG**: no version history exists. Add a `CHANGELOG.md` tracking what
+  changed between 0.x releases so consumers know what to expect when upgrading.
+- **Known limitations**: the README covers usage but does not mention the vertex
+  buffer limit or any other current constraints. A brief "Known Limitations"
+  section prevents surprises for new consumers.
+- **API stability statement**: clarify in the README whether the public API
+  (`IGraphics`, `SurfaceContext`, `Application`, etc.) is considered stable at
+  1.0, and what the compatibility policy is going forward.

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,62 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+Entries are generated automatically from git history using [git-cliff](https://github.com/orhun/git-cliff).
+
+"""
+
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}\
+### {{ group }}
+{% for commit in commits %}\
+- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | split(pat="\n") | first | upper_first | trim }}
+{% endfor %}
+{% endfor %}\
+"""
+
+trim = true
+footer = ""
+
+[git]
+# Parse conventional commits (feat:, fix:, etc.) but don't discard the rest
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+
+commit_preprocessors = [
+    # Strip GitHub PR references like "(#23)" wherever they appear
+    { pattern = '\s*\(#\d+\)', replace = "" },
+    # Strip trailing periods/whitespace from subject
+    { pattern = '\.\s*$', replace = "" },
+]
+
+commit_parsers = [
+    # Skip merge commits
+    { message = "^[Mm]erge", skip = true },
+    # Skip the automated changelog update commits
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^perf", group = "Performance" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^revert", group = "Reverts" },
+    # Catch-all: plain-english commits without a conventional prefix
+    { message = ".*", group = "Changes" },
+]
+
+filter_commits = false
+
+# Tags are plain version numbers like "0.4.0" (no "v" prefix)
+tag_pattern = "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+
+ignore_tags = ""


### PR DESCRIPTION
- Add cliff.toml for git-cliff configuration
- Add CHANGELOG.md generated from full git history
- Add .github/workflows/release.yml to auto-generate CHANGELOG and create GitHub Releases on version tags
- Expand TODO.md with detailed context and proposed solutions for vertex buffer limit, SDL multi-window input routing, SurfaceContext design, test suite, precompiled headers, and documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Set up automated release workflow for semantic version tags.
  * Added changelog generation configuration for releases.

* **Documentation**
  * Updated changelog with historical entries and upcoming improvements.
  * Expanded project documentation with design considerations, testing guidance, and future work items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->