### PR TITLE
ci: add [skip ci] to CHANGELOG commit to prevent re-triggering upload…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          git diff --cached --quiet || git commit -m "chore(release): update CHANGELOG.md for ${{ github.ref_name }}"
+          git diff --cached --quiet || git commit -m "chore(release): update CHANGELOG.md for ${{ github.ref_name }} [skip ci]"
           git push origin master
 
       - name: Generate release notes (current version only)


### PR DESCRIPTION
…-lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release workflow to prevent unnecessary CI runs on automated changelog updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->