### PR TITLE
fix: MothImage::ImGui was a no-op, breaking image preview in properti…

### DIFF
--- a/src/graphics/moth_ui/moth_image.cpp
+++ b/src/graphics/moth_ui/moth_image.cpp
@@ -20,5 +20,6 @@ namespace canyon::graphics {
     }
 
     void MothImage::ImGui(moth_ui::IntVec2 const& size, moth_ui::FloatVec2 const& uv0, moth_ui::FloatVec2 const& uv1) const {
+        m_baseImage->ImGui(size, uv0, uv1);
     }
 }


### PR DESCRIPTION
…es panel

Delegate to the underlying IImage so the texture is actually rendered and GetItemRectMin/Max returns the correct bounds for overlay drawing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image rendering in the user interface to properly display image components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->