### PR TITLE
Add fallback image support and TextureFromPixels API to ImageFactory

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -48,7 +48,7 @@ commit_parsers = [
     { message = "^fix", group = "2. Bug Fixes" },
     { message = "^refactor", group = "3. Refactoring" },
     { message = "^perf", group = "4. Performance" },
-    { message = "^doc", group = "5. Documentation" },
+    { message = "^docs", group = "5. Documentation" },
     { message = "^test", group = "6. Testing" },
     { message = "^chore", group = "7. Miscellaneous" },
     { message = "^revert", group = "8. Reverts" },

--- a/cliff.toml
+++ b/cliff.toml
@@ -14,7 +14,7 @@ body = """
 ## [Unreleased]
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}\
-### {{ group }}
+### {{ group | split(pat=". ") | last }}
 {% for commit in commits %}\
 - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | split(pat="\n") | first | upper_first | trim }}
 {% endfor %}
@@ -42,16 +42,18 @@ commit_parsers = [
     { message = "^[Mm]erge", skip = true },
     # Skip the automated changelog update commits
     { message = "^chore\\(release\\)", skip = true },
-    { message = "^feat", group = "Features" },
-    { message = "^fix", group = "Bug Fixes" },
-    { message = "^refactor", group = "Refactoring" },
-    { message = "^perf", group = "Performance" },
-    { message = "^doc", group = "Documentation" },
-    { message = "^test", group = "Testing" },
-    { message = "^chore", group = "Miscellaneous" },
-    { message = "^revert", group = "Reverts" },
+    # Skip CI commits
+    { message = "^ci", skip = true },
+    { message = "^feat", group = "1. Features" },
+    { message = "^fix", group = "2. Bug Fixes" },
+    { message = "^refactor", group = "3. Refactoring" },
+    { message = "^perf", group = "4. Performance" },
+    { message = "^doc", group = "5. Documentation" },
+    { message = "^test", group = "6. Testing" },
+    { message = "^chore", group = "7. Miscellaneous" },
+    { message = "^revert", group = "8. Reverts" },
     # Catch-all: plain-english commits without a conventional prefix
-    { message = ".*", group = "Changes" },
+    { message = ".*", group = "9. Changes" },
 ]
 
 filter_commits = false

--- a/include/moth_graphics/graphics/asset_context.h
+++ b/include/moth_graphics/graphics/asset_context.h
@@ -36,5 +36,12 @@ namespace moth_graphics::graphics {
         /// @brief Load an image directly from a file, combining texture load and image wrap.
         /// @returns Loaded image, or @c nullptr on failure.
         virtual std::unique_ptr<IImage> ImageFromFile(std::filesystem::path const& path) = 0;
+
+        /// @brief Create a texture from raw RGBA pixel data (4 bytes per pixel: R, G, B, A).
+        /// @param width Texture width in pixels.
+        /// @param height Texture height in pixels.
+        /// @param pixels Pointer to @c width * height * 4 bytes of RGBA data.
+        /// @returns Loaded texture, or @c nullptr on failure.
+        virtual std::unique_ptr<ITexture> TextureFromPixels(int width, int height, uint8_t const* pixels) = 0;
     };
 }

--- a/include/moth_graphics/graphics/image_factory.h
+++ b/include/moth_graphics/graphics/image_factory.h
@@ -6,6 +6,7 @@
 #include "moth_graphics/utils/rect.h"
 
 #include <unordered_map>
+#include <optional>
 #include <string>
 #include <memory>
 #include <filesystem>
@@ -38,9 +39,14 @@ namespace moth_graphics::graphics {
         ///
         /// If a texture pack has been loaded and contains the given path, the
         /// image is sourced from the atlas. Otherwise the file is loaded directly.
+        /// Returns the fallback image if the path cannot be loaded and one has been set.
         /// @param path Path to the image file.
         /// @returns A new image handle, or @c nullptr on failure.
         std::unique_ptr<IImage> GetImage(std::filesystem::path const& path);
+
+        /// @brief Register a texture to return as a fallback when an image cannot be loaded.
+        /// @param texture Texture to use for the fallback; covers the full texture dimensions.
+        void SetFallbackImage(std::shared_ptr<ITexture> texture);
 
     private:
         struct ImageDesc {
@@ -51,5 +57,6 @@ namespace moth_graphics::graphics {
 
         AssetContext& m_context;
         std::unordered_map<std::string, ImageDesc> m_cachedImages;
+        std::optional<ImageDesc> m_fallbackDesc;
     };
 }

--- a/include/moth_graphics/graphics/sdl/sdl_asset_context.h
+++ b/include/moth_graphics/graphics/sdl/sdl_asset_context.h
@@ -22,6 +22,7 @@ namespace moth_graphics::graphics::sdl {
         std::unique_ptr<IFont> FontFromFile(std::filesystem::path const& path, uint32_t size) override;
         std::unique_ptr<ITexture> TextureFromFile(std::filesystem::path const& path) override;
         std::unique_ptr<IImage> ImageFromFile(std::filesystem::path const& path) override;
+        std::unique_ptr<ITexture> TextureFromPixels(int width, int height, uint8_t const* pixels) override;
 
     private:
         SurfaceContext& m_context;

--- a/include/moth_graphics/graphics/vulkan/vulkan_asset_context.h
+++ b/include/moth_graphics/graphics/vulkan/vulkan_asset_context.h
@@ -22,6 +22,7 @@ namespace moth_graphics::graphics::vulkan {
         std::unique_ptr<IFont> FontFromFile(std::filesystem::path const& path, uint32_t size) override;
         std::unique_ptr<ITexture> TextureFromFile(std::filesystem::path const& path) override;
         std::unique_ptr<IImage> ImageFromFile(std::filesystem::path const& path) override;
+        std::unique_ptr<ITexture> TextureFromPixels(int width, int height, uint8_t const* pixels) override;
 
     private:
         SurfaceContext& m_context;

--- a/include/moth_graphics/platform/window.h
+++ b/include/moth_graphics/platform/window.h
@@ -65,6 +65,9 @@ namespace moth_graphics::platform {
         /// @brief Returns the moth_ui layer stack for this window.
         moth_ui::LayerStack& GetLayerStack() const { return *m_layerStack; }
 
+        /// @brief Returns the image factory for this window.
+        graphics::ImageFactory& GetImageFactory() const { return *m_imageFactory; }
+
     protected:
         /// @brief Called after the native window and graphics objects are created.
         void PostCreate();

--- a/src/graphics/image_factory.cpp
+++ b/src/graphics/image_factory.cpp
@@ -102,7 +102,17 @@ namespace moth_graphics::graphics {
             m_cachedImages.insert(std::make_pair(key, cacheDesc));
             return m_context.NewImage(texture, sourceRect);
         }
+        if (m_fallbackDesc) {
+            spdlog::warn("ImageFactory: '{}' not found, using fallback", path.string());
+            return m_context.NewImage(m_fallbackDesc->m_texture, m_fallbackDesc->m_sourceRect);
+        }
+        spdlog::error("ImageFactory: '{}' not found and no fallback set", path.string());
         return nullptr;
+    }
+
+    void ImageFactory::SetFallbackImage(std::shared_ptr<ITexture> texture) {
+        IntRect const sourceRect{ { 0, 0 }, { texture->GetWidth(), texture->GetHeight() } };
+        m_fallbackDesc = ImageDesc{ texture, sourceRect, {} };
     }
 }
 

--- a/src/graphics/image_factory.cpp
+++ b/src/graphics/image_factory.cpp
@@ -111,6 +111,10 @@ namespace moth_graphics::graphics {
     }
 
     void ImageFactory::SetFallbackImage(std::shared_ptr<ITexture> texture) {
+        if (!texture) {
+            m_fallbackDesc.reset();
+            return;
+        }
         IntRect const sourceRect{ { 0, 0 }, { texture->GetWidth(), texture->GetHeight() } };
         m_fallbackDesc = ImageDesc{ texture, sourceRect, {} };
     }

--- a/src/graphics/sdl/sdl_asset_context.cpp
+++ b/src/graphics/sdl/sdl_asset_context.cpp
@@ -39,9 +39,9 @@ namespace moth_graphics::graphics::sdl {
             return nullptr;
         }
         // Use a streaming texture so we can lock and write the pixel data directly.
-        // SDL_PIXELFORMAT_ABGR8888 stores bytes as R,G,B,A in memory on little-endian
-        // systems, matching our input layout.
-        SDL_Texture* tex = SDL_CreateTexture(m_context.GetRenderer(), SDL_PIXELFORMAT_ABGR8888, SDL_TEXTUREACCESS_STREAMING, width, height);
+        // SDL_PIXELFORMAT_RGBA32 is an endian-neutral alias that always matches
+        // pixels laid out in memory as R, G, B, A bytes.
+        SDL_Texture* tex = SDL_CreateTexture(m_context.GetRenderer(), SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_STREAMING, width, height);
         if (tex == nullptr) {
             return nullptr;
         }

--- a/src/graphics/sdl/sdl_asset_context.cpp
+++ b/src/graphics/sdl/sdl_asset_context.cpp
@@ -35,6 +35,9 @@ namespace moth_graphics::graphics::sdl {
     }
 
     std::unique_ptr<ITexture> AssetContext::TextureFromPixels(int width, int height, uint8_t const* pixels) {
+        if (pixels == nullptr) {
+            return nullptr;
+        }
         // Use a streaming texture so we can lock and write the pixel data directly.
         // SDL_PIXELFORMAT_ABGR8888 stores bytes as R,G,B,A in memory on little-endian
         // systems, matching our input layout.
@@ -54,6 +57,8 @@ namespace moth_graphics::graphics::sdl {
             SDL_UnlockTexture(tex);
         } else {
             spdlog::error("TextureFromPixels: SDL_LockTexture failed: {}", SDL_GetError());
+            SDL_DestroyTexture(tex);
+            return nullptr;
         }
         return std::make_unique<Texture>(CreateTextureRef(tex));
     }

--- a/src/graphics/sdl/sdl_asset_context.cpp
+++ b/src/graphics/sdl/sdl_asset_context.cpp
@@ -34,6 +34,30 @@ namespace moth_graphics::graphics::sdl {
         return Texture::FromFile(m_context.GetRenderer(), path);
     }
 
+    std::unique_ptr<ITexture> AssetContext::TextureFromPixels(int width, int height, uint8_t const* pixels) {
+        // Use a streaming texture so we can lock and write the pixel data directly.
+        // SDL_PIXELFORMAT_ABGR8888 stores bytes as R,G,B,A in memory on little-endian
+        // systems, matching our input layout.
+        SDL_Texture* tex = SDL_CreateTexture(m_context.GetRenderer(), SDL_PIXELFORMAT_ABGR8888, SDL_TEXTUREACCESS_STREAMING, width, height);
+        if (tex == nullptr) {
+            return nullptr;
+        }
+        void* texData = nullptr;
+        int pitch = 0;
+        if (SDL_LockTexture(tex, nullptr, &texData, &pitch) == 0) {
+            int const rowBytes = width * 4;
+            for (int row = 0; row < height; ++row) {
+                auto* dst = static_cast<uint8_t*>(texData) + (row * pitch);
+                auto const* src = pixels + (row * rowBytes);
+                std::copy(src, src + rowBytes, dst);
+            }
+            SDL_UnlockTexture(tex);
+        } else {
+            spdlog::error("TextureFromPixels: SDL_LockTexture failed: {}", SDL_GetError());
+        }
+        return std::make_unique<Texture>(CreateTextureRef(tex));
+    }
+
     std::unique_ptr<IImage> AssetContext::ImageFromFile(std::filesystem::path const& path) {
         auto rawTexture = TextureFromFile(path);
         if (!rawTexture) {

--- a/src/graphics/sdl/sdl_texture.cpp
+++ b/src/graphics/sdl/sdl_texture.cpp
@@ -26,10 +26,15 @@ namespace moth_graphics::graphics::sdl {
     }
 
     std::unique_ptr<Texture> Texture::FromFile(SDL_Renderer* renderer, std::filesystem::path const& path) {
-        if (auto texture = CreateTextureRef(renderer, path)) {
-            return std::make_unique<Texture>(texture);
+        auto surface = CreateSurfaceRef(path);
+        if (!surface) {
+            return nullptr;
         }
-        return nullptr;
+        auto texture = CreateTextureRef(renderer, surface);
+        if (!texture || texture->GetImpl() == nullptr) {
+            return nullptr;
+        }
+        return std::make_unique<Texture>(texture);
     }
 
 }

--- a/src/graphics/vulkan/vulkan_asset_context.cpp
+++ b/src/graphics/vulkan/vulkan_asset_context.cpp
@@ -34,6 +34,10 @@ namespace moth_graphics::graphics::vulkan {
         return Texture::FromFile(m_context, path);
     }
 
+    std::unique_ptr<ITexture> AssetContext::TextureFromPixels(int width, int height, uint8_t const* pixels) {
+        return Texture::FromRGBA(m_context, width, height, pixels);
+    }
+
     std::unique_ptr<IImage> AssetContext::ImageFromFile(std::filesystem::path const& path) {
         auto texture = TextureFromFile(path);
         if (!texture) {

--- a/src/graphics/vulkan/vulkan_texture.cpp
+++ b/src/graphics/vulkan/vulkan_texture.cpp
@@ -10,35 +10,19 @@ namespace {
 
 namespace moth_graphics::graphics::vulkan {
     std::unique_ptr<Texture> Texture::FromFile(SurfaceContext& context, std::filesystem::path const& path) {
-        if (std::filesystem::exists(path)) {
-            int texWidth = 0;
-            int texHeight = 0;
-            int texChannels = 0;
-            stbi_uc* pixels = stbi_load(path.string().c_str(), &texWidth, &texHeight, &texChannels, STBI_rgb_alpha);
-            VkDeviceSize imageSize = texWidth * texHeight * 4;
-            if (pixels != nullptr) {
-                auto stagingBuffer = std::make_unique<Buffer>(context, imageSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-
-                void* data = stagingBuffer->Map();
-                memcpy(data, pixels, static_cast<size_t>(imageSize));
-                stagingBuffer->Unmap();
-
-                stbi_image_free(pixels);
-
-                VkFormat const format = VK_FORMAT_R8G8B8A8_UNORM;
-                auto newImage = std::make_unique<Texture>(context, texWidth, texHeight, format, VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
-
-                auto commandBuffer = std::make_unique<CommandBuffer>(context);
-                commandBuffer->BeginRecord();
-                commandBuffer->TransitionImageLayout(*newImage, format, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-                commandBuffer->CopyBufferToImage(*newImage, *stagingBuffer);
-                commandBuffer->TransitionImageLayout(*newImage, format, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-                commandBuffer->SubmitAndWait();
-
-                return newImage;
-            }
+        if (!std::filesystem::exists(path)) {
+            return nullptr;
         }
-        return nullptr;
+        int texWidth = 0;
+        int texHeight = 0;
+        int texChannels = 0;
+        stbi_uc* pixels = stbi_load(path.string().c_str(), &texWidth, &texHeight, &texChannels, STBI_rgb_alpha);
+        if (pixels == nullptr) {
+            return nullptr;
+        }
+        auto texture = FromRGBA(context, texWidth, texHeight, pixels);
+        stbi_image_free(pixels);
+        return texture;
     }
 
     std::unique_ptr<Texture> Texture::FromRGBA(SurfaceContext& context, int width, int height, unsigned char const* pixels) {

--- a/src/platform/window.cpp
+++ b/src/platform/window.cpp
@@ -15,13 +15,14 @@ namespace moth_graphics::platform {
 
     void Window::PostCreate() {
         auto& assetContext = GetSurfaceContext().GetAssetContext();
-        m_imageFactory = std::make_unique<moth_graphics::graphics::ImageFactory>(assetContext);
+        m_imageFactory = std::make_shared<moth_graphics::graphics::ImageFactory>(assetContext);
         m_fontFactory = std::make_unique<moth_graphics::graphics::FontFactory>(assetContext);
         m_uiRenderer = std::make_unique<moth_graphics::graphics::MothRenderer>(*m_graphics);
         m_mothImageFactory = std::make_unique<moth_graphics::graphics::MothImageFactory>(m_imageFactory);
         m_mothFontFactory = std::make_unique<moth_graphics::graphics::MothFontFactory>(m_fontFactory);
         m_mothContext = std::make_shared<moth_ui::Context>(m_mothImageFactory.get(), m_mothFontFactory.get(), m_uiRenderer.get());
         m_layerStack = std::make_unique<moth_ui::LayerStack>(*m_uiRenderer, m_windowWidth, m_windowHeight, m_windowWidth, m_windowHeight);
+
     }
 
     void Window::PreDestroy() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create textures directly from raw pixel data.
  * Register a fallback image to use when requested assets are missing.
  * Access the image factory from the window for flexible resource sharing.

* **Improvements**
  * Better texture loading error handling and logging.
  * Changelog display now shows simplified group headings and uses numbered group labels; CI-style commits are ignored in changelogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->