### PR TITLE
Refactor AssetContext ownership and improve LoadTexturePack handling

### DIFF
--- a/include/moth_graphics/graphics/asset_context.h
+++ b/include/moth_graphics/graphics/asset_context.h
@@ -10,6 +10,9 @@
 #include <cstdint>
 
 namespace moth_graphics::graphics {
+    class FontFactory;
+    class ImageFactory;
+
     /// @brief Per-window asset loading interface.
     ///
     /// Obtained from SurfaceContext::GetAssetContext(). Provides factory methods
@@ -19,6 +22,12 @@ namespace moth_graphics::graphics {
     class AssetContext {
     public:
         virtual ~AssetContext() = default;
+
+        /// @brief Returns the cached image factory for this context.
+        virtual ImageFactory& GetImageFactory() = 0;
+
+        /// @brief Returns the cached font factory for this context.
+        virtual FontFactory& GetFontFactory() = 0;
 
         /// @brief Wrap an existing texture in a new image covering the full texture.
         virtual std::unique_ptr<IImage> NewImage(std::shared_ptr<ITexture> texture) = 0;

--- a/include/moth_graphics/graphics/moth_ui/moth_font_factory.h
+++ b/include/moth_graphics/graphics/moth_ui/moth_font_factory.h
@@ -10,13 +10,13 @@
 namespace moth_graphics::graphics {
     class MothFontFactory : public moth_ui::FontFactory {
     public:
-        explicit MothFontFactory(std::shared_ptr<moth_graphics::graphics::FontFactory> factoryImpl);
+        explicit MothFontFactory(moth_graphics::graphics::FontFactory& factoryImpl);
         ~MothFontFactory() override = default;
 
         void ClearFonts() override;
         std::shared_ptr<moth_ui::IFont> GetFont(std::string const& name, int size) override;
 
     private:
-        std::shared_ptr<moth_graphics::graphics::FontFactory> m_factoryImpl;
+        moth_graphics::graphics::FontFactory& m_factoryImpl;
     };
 }

--- a/include/moth_graphics/graphics/moth_ui/moth_image_factory.h
+++ b/include/moth_graphics/graphics/moth_ui/moth_image_factory.h
@@ -11,7 +11,7 @@
 namespace moth_graphics::graphics {
     class MothImageFactory : public moth_ui::IImageFactory {
     public:
-        explicit MothImageFactory(std::shared_ptr<graphics::ImageFactory> factoryImpl);
+        explicit MothImageFactory(graphics::ImageFactory& factoryImpl);
         ~MothImageFactory() override = default;
 
         void FlushCache() override;
@@ -19,7 +19,7 @@ namespace moth_graphics::graphics {
         std::unique_ptr<moth_ui::IImage> GetImage(std::filesystem::path const& path) override;
 
     private:
-        std::shared_ptr<graphics::ImageFactory> m_factoryImpl;
+        graphics::ImageFactory& m_factoryImpl;
     };
 }
 

--- a/include/moth_graphics/graphics/sdl/sdl_asset_context.h
+++ b/include/moth_graphics/graphics/sdl/sdl_asset_context.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "moth_graphics/graphics/asset_context.h"
+#include "moth_graphics/graphics/font_factory.h"
+#include "moth_graphics/graphics/image_factory.h"
 #include "moth_graphics/graphics/ifont.h"
 #include "moth_graphics/graphics/iimage.h"
 #include "moth_graphics/graphics/itexture.h"
@@ -17,6 +19,9 @@ namespace moth_graphics::graphics::sdl {
         explicit AssetContext(SurfaceContext& context);
         ~AssetContext() override = default;
 
+        graphics::ImageFactory& GetImageFactory() override { return m_imageFactory; }
+        graphics::FontFactory& GetFontFactory() override { return m_fontFactory; }
+
         std::unique_ptr<IImage> NewImage(std::shared_ptr<ITexture> texture) override;
         std::unique_ptr<IImage> NewImage(std::shared_ptr<ITexture> texture, IntRect const& sourceRect) override;
         std::unique_ptr<IFont> FontFromFile(std::filesystem::path const& path, uint32_t size) override;
@@ -26,5 +31,7 @@ namespace moth_graphics::graphics::sdl {
 
     private:
         SurfaceContext& m_context;
+        graphics::ImageFactory m_imageFactory;
+        graphics::FontFactory m_fontFactory;
     };
 }

--- a/include/moth_graphics/graphics/sdl/sdl_asset_context.h
+++ b/include/moth_graphics/graphics/sdl/sdl_asset_context.h
@@ -19,6 +19,11 @@ namespace moth_graphics::graphics::sdl {
         explicit AssetContext(SurfaceContext& context);
         ~AssetContext() override = default;
 
+        AssetContext(AssetContext const&) = delete;
+        AssetContext& operator=(AssetContext const&) = delete;
+        AssetContext(AssetContext&&) = delete;
+        AssetContext& operator=(AssetContext&&) = delete;
+
         graphics::ImageFactory& GetImageFactory() override { return m_imageFactory; }
         graphics::FontFactory& GetFontFactory() override { return m_fontFactory; }
 

--- a/include/moth_graphics/graphics/vulkan/vulkan_asset_context.h
+++ b/include/moth_graphics/graphics/vulkan/vulkan_asset_context.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "moth_graphics/graphics/asset_context.h"
+#include "moth_graphics/graphics/font_factory.h"
+#include "moth_graphics/graphics/image_factory.h"
 #include "moth_graphics/graphics/ifont.h"
 #include "moth_graphics/graphics/iimage.h"
 #include "moth_graphics/graphics/itexture.h"
@@ -17,6 +19,9 @@ namespace moth_graphics::graphics::vulkan {
         explicit AssetContext(SurfaceContext& context);
         ~AssetContext() override = default;
 
+        graphics::ImageFactory& GetImageFactory() override { return m_imageFactory; }
+        graphics::FontFactory& GetFontFactory() override { return m_fontFactory; }
+
         std::unique_ptr<IImage> NewImage(std::shared_ptr<ITexture> texture) override;
         std::unique_ptr<IImage> NewImage(std::shared_ptr<ITexture> texture, IntRect const& sourceRect) override;
         std::unique_ptr<IFont> FontFromFile(std::filesystem::path const& path, uint32_t size) override;
@@ -26,5 +31,7 @@ namespace moth_graphics::graphics::vulkan {
 
     private:
         SurfaceContext& m_context;
+        graphics::ImageFactory m_imageFactory;
+        graphics::FontFactory m_fontFactory;
     };
 }

--- a/include/moth_graphics/graphics/vulkan/vulkan_asset_context.h
+++ b/include/moth_graphics/graphics/vulkan/vulkan_asset_context.h
@@ -19,6 +19,11 @@ namespace moth_graphics::graphics::vulkan {
         explicit AssetContext(SurfaceContext& context);
         ~AssetContext() override = default;
 
+        AssetContext(AssetContext const&) = delete;
+        AssetContext& operator=(AssetContext const&) = delete;
+        AssetContext(AssetContext&&) = delete;
+        AssetContext& operator=(AssetContext&&) = delete;
+
         graphics::ImageFactory& GetImageFactory() override { return m_imageFactory; }
         graphics::FontFactory& GetFontFactory() override { return m_fontFactory; }
 

--- a/include/moth_graphics/platform/window.h
+++ b/include/moth_graphics/platform/window.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "moth_graphics/events/event_emitter.h"
-#include "moth_graphics/graphics/font_factory.h"
 #include "moth_graphics/graphics/igraphics.h"
-#include "moth_graphics/graphics/image_factory.h"
 #include "moth_graphics/graphics/moth_ui/moth_font_factory.h"
 #include "moth_graphics/graphics/moth_ui/moth_image_factory.h"
 #include "moth_graphics/graphics/moth_ui/moth_renderer.h"
@@ -66,7 +64,7 @@ namespace moth_graphics::platform {
         moth_ui::LayerStack& GetLayerStack() const { return *m_layerStack; }
 
         /// @brief Returns the image factory for this window.
-        graphics::ImageFactory& GetImageFactory() const { return *m_imageFactory; }
+        graphics::ImageFactory& GetImageFactory() const;
 
     protected:
         /// @brief Called after the native window and graphics objects are created.
@@ -84,9 +82,6 @@ namespace moth_graphics::platform {
 
         std::unique_ptr<graphics::IGraphics> m_graphics;
         std::unique_ptr<moth_ui::LayerStack> m_layerStack;
-
-        std::shared_ptr<graphics::ImageFactory> m_imageFactory;
-        std::shared_ptr<graphics::FontFactory> m_fontFactory;
 
         std::unique_ptr<graphics::MothImageFactory> m_mothImageFactory;
         std::unique_ptr<graphics::MothFontFactory> m_mothFontFactory;

--- a/include/moth_graphics/platform/window.h
+++ b/include/moth_graphics/platform/window.h
@@ -19,9 +19,11 @@ namespace moth_graphics::platform {
 
     /// @brief A platform window and its associated rendering resources.
     ///
-    /// Owns the @c IGraphics instance, the moth_ui @c LayerStack, and the asset
-    /// factories for images and fonts. Subclasses handle the platform-specific
-    /// window creation (see @c sdl::Window and @c glfw::Window).
+    /// Owns the @c IGraphics instance, the moth_ui @c LayerStack, and the
+    /// @c MothImageFactory / @c MothFontFactory adapter wrappers. The underlying
+    /// image and font factories are owned by the @c AssetContext. Subclasses
+    /// handle the platform-specific window creation (see @c sdl::Window and
+    /// @c glfw::Window).
     class Window : public EventEmitter {
     public:
         /// @param windowTitle Initial title bar text.

--- a/src/graphics/image_factory.cpp
+++ b/src/graphics/image_factory.cpp
@@ -64,8 +64,7 @@ namespace moth_graphics::graphics {
                 spdlog::error("LoadTexturePack: failed to load atlas texture '{}'", atlasAbsPath.string());
                 continue;
             }
-            auto sharedTexture = std::shared_ptr<ITexture>(texture.release());
-
+            auto sharedTexture = std::shared_ptr<ITexture>(std::move(texture));
             for (auto&& imageJson : atlasJson["images"]) {
                 if (!imageJson.is_object()) {
                     spdlog::error("LoadTexturePack: '{}': image entry is not an object", atlasAbsPath.string());

--- a/src/graphics/image_factory.cpp
+++ b/src/graphics/image_factory.cpp
@@ -74,9 +74,14 @@ namespace moth_graphics::graphics {
                     ImageDesc desc;
                     desc.m_texture = sharedTexture;
                     desc.m_path = absPath;
-                    imageJson.at("rect").get_to(desc.m_sourceRect);
+                    auto const& rectJson = imageJson.at("rect");
+                    int const x = rectJson.at("x").get<int>();
+                    int const y = rectJson.at("y").get<int>();
+                    int const w = rectJson.at("w").get<int>();
+                    int const h = rectJson.at("h").get<int>();
+                    desc.m_sourceRect = moth_graphics::MakeRect(x, y, w, h);
                     m_cachedImages.insert(std::make_pair(absPath.string(), desc));
-                } catch (std::exception&) {
+                } catch (std::exception& e) {
                     continue;
                 }
             }

--- a/src/graphics/image_factory.cpp
+++ b/src/graphics/image_factory.cpp
@@ -40,6 +40,7 @@ namespace moth_graphics::graphics {
             return false;
         }
 
+        bool anyCached = false;
         for (auto&& atlasJson : json["atlases"]) {
             if (!atlasJson.is_object()) {
                 spdlog::error("LoadTexturePack: '{}': atlas entry is not an object", path.string());
@@ -92,6 +93,7 @@ namespace moth_graphics::graphics {
                     int const h = rectJson.at("h").get<int>();
                     desc.m_sourceRect = moth_graphics::MakeRect(x, y, w, h);
                     m_cachedImages.insert(std::make_pair(absPath.string(), desc));
+                    anyCached = true;
                 } catch (std::exception& e) {
                     spdlog::error("LoadTexturePack: '{}': failed to load image entry: {}", atlasAbsPath.string(), e.what());
                     continue;
@@ -99,7 +101,7 @@ namespace moth_graphics::graphics {
             }
         }
 
-        return true;
+        return anyCached;
     }
 
     std::unique_ptr<IImage> ImageFactory::GetImage(std::filesystem::path const& path) {

--- a/src/graphics/image_factory.cpp
+++ b/src/graphics/image_factory.cpp
@@ -17,33 +17,40 @@ namespace moth_graphics::graphics {
         auto const rootPath = path.parent_path();
 
         if (!std::filesystem::exists(path)) {
+            spdlog::error("LoadTexturePack: '{}' does not exist", path.string());
             return false;
         }
 
         std::ifstream ifile(path);
         if (!ifile.is_open()) {
+            spdlog::error("LoadTexturePack: failed to open '{}'", path.string());
             return false;
         }
 
         nlohmann::json json;
         try {
             ifile >> json;
-        } catch (std::exception&) {
+        } catch (std::exception& e) {
+            spdlog::error("LoadTexturePack: failed to parse '{}': {}", path.string(), e.what());
             return false;
         }
 
         if (!json.contains("atlases") || !json["atlases"].is_array()) {
+            spdlog::error("LoadTexturePack: '{}' is missing or has invalid 'atlases' array", path.string());
             return false;
         }
 
         for (auto&& atlasJson : json["atlases"]) {
             if (!atlasJson.is_object()) {
+                spdlog::error("LoadTexturePack: '{}': atlas entry is not an object", path.string());
                 continue;
             }
             if (!atlasJson.contains("atlas") || !atlasJson["atlas"].is_string()) {
+                spdlog::error("LoadTexturePack: '{}': atlas entry missing 'atlas' string field", path.string());
                 continue;
             }
             if (!atlasJson.contains("images") || !atlasJson["images"].is_array()) {
+                spdlog::error("LoadTexturePack: '{}': atlas entry missing 'images' array", path.string());
                 continue;
             }
 
@@ -53,18 +60,22 @@ namespace moth_graphics::graphics {
 
             auto texture = m_context.TextureFromFile(atlasAbsPath);
             if (!texture) {
+                spdlog::error("LoadTexturePack: failed to load atlas texture '{}'", atlasAbsPath.string());
                 continue;
             }
             auto sharedTexture = std::shared_ptr<ITexture>(texture.release());
 
             for (auto&& imageJson : atlasJson["images"]) {
                 if (!imageJson.is_object()) {
+                    spdlog::error("LoadTexturePack: '{}': image entry is not an object", atlasAbsPath.string());
                     continue;
                 }
                 if (!imageJson.contains("path") || !imageJson["path"].is_string()) {
+                    spdlog::error("LoadTexturePack: '{}': image entry missing 'path' string field", atlasAbsPath.string());
                     continue;
                 }
                 if (!imageJson.contains("rect") || !imageJson["rect"].is_object()) {
+                    spdlog::error("LoadTexturePack: '{}': image entry missing 'rect' object", atlasAbsPath.string());
                     continue;
                 }
                 try {
@@ -82,6 +93,7 @@ namespace moth_graphics::graphics {
                     desc.m_sourceRect = moth_graphics::MakeRect(x, y, w, h);
                     m_cachedImages.insert(std::make_pair(absPath.string(), desc));
                 } catch (std::exception& e) {
+                    spdlog::error("LoadTexturePack: '{}': failed to load image entry: {}", atlasAbsPath.string(), e.what());
                     continue;
                 }
             }

--- a/src/graphics/moth_ui/moth_font_factory.cpp
+++ b/src/graphics/moth_ui/moth_font_factory.cpp
@@ -4,18 +4,18 @@
 #include "moth_graphics/graphics/moth_ui/moth_font.h"
 
 namespace moth_graphics::graphics {
-    MothFontFactory::MothFontFactory(std::shared_ptr<moth_graphics::graphics::FontFactory> factoryImpl)
+    MothFontFactory::MothFontFactory(moth_graphics::graphics::FontFactory& factoryImpl)
         : m_factoryImpl(factoryImpl) {
     }
 
     void MothFontFactory::ClearFonts() {
-        m_factoryImpl->ClearFonts();
+        m_factoryImpl.ClearFonts();
     }
 
     std::shared_ptr<moth_ui::IFont> MothFontFactory::GetFont(std::string const& name, int size) {
         auto it = m_fontPaths.find(name);
         if (it != m_fontPaths.end()) {
-           auto const font = m_factoryImpl->GetFont(it->second.string(), size);
+           auto const font = m_factoryImpl.GetFont(it->second.string(), size);
            return std::make_shared<MothFont>(font);
         }
         return nullptr;

--- a/src/graphics/moth_ui/moth_image_factory.cpp
+++ b/src/graphics/moth_ui/moth_image_factory.cpp
@@ -3,20 +3,20 @@
 #include "moth_graphics/graphics/moth_ui/moth_image.h"
 
 namespace moth_graphics::graphics {
-    MothImageFactory::MothImageFactory(std::shared_ptr<graphics::ImageFactory> factoryImpl)
+    MothImageFactory::MothImageFactory(graphics::ImageFactory& factoryImpl)
         : m_factoryImpl(factoryImpl) {
     }
 
     void MothImageFactory::FlushCache() {
-        m_factoryImpl->FlushCache();
+        m_factoryImpl.FlushCache();
     }
 
     bool MothImageFactory::LoadTexturePack(std::filesystem::path const& path) {
-        return m_factoryImpl->LoadTexturePack(path);
+        return m_factoryImpl.LoadTexturePack(path);
     }
 
     std::unique_ptr<::moth_ui::IImage> MothImageFactory::GetImage(std::filesystem::path const& path) {
-        std::shared_ptr<IImage> intlImage = m_factoryImpl->GetImage(path);
+        std::shared_ptr<IImage> intlImage = m_factoryImpl.GetImage(path);
         return std::make_unique<MothImage>(intlImage);
     }
 }

--- a/src/graphics/sdl/sdl_asset_context.cpp
+++ b/src/graphics/sdl/sdl_asset_context.cpp
@@ -7,7 +7,9 @@
 
 namespace moth_graphics::graphics::sdl {
     AssetContext::AssetContext(SurfaceContext& context)
-        : m_context(context) {
+        : m_context(context)
+        , m_imageFactory(*this)
+        , m_fontFactory(*this) {
     }
 
     std::unique_ptr<IImage> AssetContext::NewImage(std::shared_ptr<ITexture> texture) {

--- a/src/graphics/vulkan/vulkan_asset_context.cpp
+++ b/src/graphics/vulkan/vulkan_asset_context.cpp
@@ -7,7 +7,9 @@
 
 namespace moth_graphics::graphics::vulkan {
     AssetContext::AssetContext(SurfaceContext& context)
-        : m_context(context) {
+        : m_context(context)
+        , m_imageFactory(*this)
+        , m_fontFactory(*this) {
     }
 
     std::unique_ptr<IImage> AssetContext::NewImage(std::shared_ptr<ITexture> texture) {

--- a/src/platform/window.cpp
+++ b/src/platform/window.cpp
@@ -13,21 +13,20 @@ namespace moth_graphics::platform {
     Window::~Window() {
     }
 
+    graphics::ImageFactory& Window::GetImageFactory() const {
+        return GetSurfaceContext().GetAssetContext().GetImageFactory();
+    }
+
     void Window::PostCreate() {
         auto& assetContext = GetSurfaceContext().GetAssetContext();
-        m_imageFactory = std::make_shared<moth_graphics::graphics::ImageFactory>(assetContext);
-        m_fontFactory = std::make_unique<moth_graphics::graphics::FontFactory>(assetContext);
         m_uiRenderer = std::make_unique<moth_graphics::graphics::MothRenderer>(*m_graphics);
-        m_mothImageFactory = std::make_unique<moth_graphics::graphics::MothImageFactory>(m_imageFactory);
-        m_mothFontFactory = std::make_unique<moth_graphics::graphics::MothFontFactory>(m_fontFactory);
+        m_mothImageFactory = std::make_unique<moth_graphics::graphics::MothImageFactory>(assetContext.GetImageFactory());
+        m_mothFontFactory = std::make_unique<moth_graphics::graphics::MothFontFactory>(assetContext.GetFontFactory());
         m_mothContext = std::make_shared<moth_ui::Context>(m_mothImageFactory.get(), m_mothFontFactory.get(), m_uiRenderer.get());
         m_layerStack = std::make_unique<moth_ui::LayerStack>(*m_uiRenderer, m_windowWidth, m_windowHeight, m_windowWidth, m_windowHeight);
-
     }
 
     void Window::PreDestroy() {
-        m_imageFactory.reset();
-        m_fontFactory.reset();
         m_uiRenderer.reset();
         m_mothImageFactory.reset();
         m_mothFontFactory.reset();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting and failure handling when loading image/texture packs; load now reports and fails cleanly on invalid or missing entries.

* **Refactor**
  * Simplified ownership of image/font factories for clearer lifetimes and more stable resource management.
  * Asset and window integration updated so adapter wrappers obtain factories from the central asset layer, preventing duplicated ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->