### PR TITLE
refactor: move DrawSprite overloads off IGraphics to free functions

### DIFF
--- a/include/moth_graphics/graphics/igraphics.h
+++ b/include/moth_graphics/graphics/igraphics.h
@@ -5,7 +5,6 @@
 #include "moth_graphics/graphics/ifont.h"
 #include "moth_graphics/graphics/iimage.h"
 #include "moth_graphics/graphics/itarget.h"
-#include "moth_graphics/graphics/sprite.h"
 #include "moth_graphics/graphics/text_alignment.h"
 #include "moth_graphics/utils/rect.h"
 #include "moth_graphics/utils/transform.h"
@@ -68,52 +67,6 @@ namespace moth_graphics::graphics {
 
         /// @brief Pop the top transform, restoring the previous one.
         virtual void PopTransform() = 0;
-
-        /// @brief Draw the current frame of a sprite into a destination rectangle. The active transform is applied.
-        /// @param sprite  The sprite to draw; must be loaded with a valid clip set.
-        /// @param destRect Destination rectangle in local (pre-transform) space.
-        void DrawSprite(Sprite& sprite, IntRect const& destRect) {
-            auto const& image = sprite.GetImage();
-            if (image) {
-                auto const frameRect = sprite.GetCurrentFrameRect();
-                DrawImage(image, destRect, &frameRect);
-            }
-        }
-
-        /// @brief Draw the current frame of a sprite at a position, offset by @p pivot.
-        /// @param sprite The sprite to draw at its natural frame size.
-        /// @param pos    Destination point in logical pixels.
-        /// @param pivot  Normalized pivot within the frame: {0,0} = top-left, {0.5,0.5} = center,
-        ///               {1,1} = bottom-right.
-        void DrawSprite(Sprite& sprite, IntVec2 const& pos, FloatVec2 const& pivot) {
-            auto const& image = sprite.GetImage();
-            if (image) {
-                auto const frameRect = sprite.GetCurrentFrameRect();
-                IntRect const destRect = MakeRect(
-                    pos.x - static_cast<int>(pivot.x * static_cast<float>(frameRect.w())),
-                    pos.y - static_cast<int>(pivot.y * static_cast<float>(frameRect.h())),
-                    frameRect.w(),
-                    frameRect.h());
-                DrawImage(image, destRect, &frameRect);
-            }
-        }
-
-        /// @brief Draw the current frame of a sprite at @p pos, with the frame's own per-frame pivot aligned to that point.
-        /// @param sprite The sprite to draw at its natural frame size.
-        /// @param pos    The screen point that the frame's pivot should land on.
-        void DrawSprite(Sprite& sprite, IntVec2 const& pos) {
-            auto const& image = sprite.GetImage();
-            if (image) {
-                auto const frameRect  = sprite.GetCurrentFrameRect();
-                auto const framePivot = sprite.GetCurrentFramePivot();
-                IntRect const destRect = MakeRect(
-                    pos.x - framePivot.x,
-                    pos.y - framePivot.y,
-                    frameRect.w(),
-                    frameRect.h());
-                DrawImage(image, destRect, &frameRect);
-            }
-        }
 
         /// @brief Draw an image into a destination rectangle in local space. The active transform is applied.
         /// @param image The image to draw.

--- a/include/moth_graphics/graphics/sprite.h
+++ b/include/moth_graphics/graphics/sprite.h
@@ -17,14 +17,11 @@ namespace moth_graphics::graphics {
     /// of any rendering layer. Call Update() each frame with the elapsed time in
     /// milliseconds, then use GetCurrentFrameRect() and GetImage() to render.
     ///
-    /// A Sprite must always have an associated sprite sheet. Use Create() to
-    /// construct one; it returns @c nullptr if the sheet has no frames.
+    /// Construct with a sprite sheet; SpriteSheet already enforces non-empty
+    /// frames, so a successfully loaded sheet is always valid.
     class Sprite {
     public:
-        /// @brief Attempt to create a Sprite from a sprite sheet.
-        /// @param spriteSheet The sprite sheet to animate. Must not be null.
-        /// @return A Sprite on success, or @c nullptr if the sheet has no frames.
-        static std::unique_ptr<Sprite> Create(std::shared_ptr<SpriteSheet> spriteSheet);
+        explicit Sprite(std::shared_ptr<SpriteSheet> spriteSheet);
 
         Sprite(Sprite&&) = default;
         Sprite& operator=(Sprite&&) = default;
@@ -83,8 +80,6 @@ namespace moth_graphics::graphics {
         Image const& GetImage() const;
 
     private:
-        explicit Sprite(std::shared_ptr<SpriteSheet> spriteSheet);
-
         std::shared_ptr<SpriteSheet> m_spriteSheet;
         std::optional<SpriteSheet::ClipDesc> m_currentClip;
         std::string m_currentClipName;

--- a/include/moth_graphics/graphics/sprite.h
+++ b/include/moth_graphics/graphics/sprite.h
@@ -9,6 +9,8 @@
 #include <string_view>
 
 namespace moth_graphics::graphics {
+    class IGraphics;
+
     /// @brief Animated sprite driven by a SpriteSheet.
     ///
     /// Manages clip selection, frame advancement, and loop behaviour independently
@@ -90,4 +92,13 @@ namespace moth_graphics::graphics {
         float m_accumulatedMs = 0.0f;
         bool m_playing = false;
     };
+
+    /// @brief Draw the current frame of a sprite into a destination rectangle.
+    void DrawSprite(IGraphics& graphics, Sprite& sprite, IntRect const& destRect);
+
+    /// @brief Draw the current frame of a sprite at a position, offset by a normalized pivot.
+    void DrawSprite(IGraphics& graphics, Sprite& sprite, IntVec2 const& pos, FloatVec2 const& pivot);
+
+    /// @brief Draw the current frame of a sprite at a position using the frame's own pivot.
+    void DrawSprite(IGraphics& graphics, Sprite& sprite, IntVec2 const& pos);
 }

--- a/include/moth_graphics/graphics/sprite.h
+++ b/include/moth_graphics/graphics/sprite.h
@@ -94,11 +94,11 @@ namespace moth_graphics::graphics {
     };
 
     /// @brief Draw the current frame of a sprite into a destination rectangle.
-    void DrawSprite(IGraphics& graphics, Sprite& sprite, IntRect const& destRect);
+    void DrawSprite(IGraphics& graphics, Sprite const& sprite, IntRect const& destRect);
 
     /// @brief Draw the current frame of a sprite at a position, offset by a normalized pivot.
-    void DrawSprite(IGraphics& graphics, Sprite& sprite, IntVec2 const& pos, FloatVec2 const& pivot);
+    void DrawSprite(IGraphics& graphics, Sprite const& sprite, IntVec2 const& pos, FloatVec2 const& pivot);
 
     /// @brief Draw the current frame of a sprite at a position using the frame's own pivot.
-    void DrawSprite(IGraphics& graphics, Sprite& sprite, IntVec2 const& pos);
+    void DrawSprite(IGraphics& graphics, Sprite const& sprite, IntVec2 const& pos);
 }

--- a/src/graphics/sprite.cpp
+++ b/src/graphics/sprite.cpp
@@ -3,18 +3,6 @@
 #include "moth_graphics/graphics/igraphics.h"
 
 namespace moth_graphics::graphics {
-    std::unique_ptr<Sprite> Sprite::Create(std::shared_ptr<SpriteSheet> spriteSheet) {
-        if (!spriteSheet) {
-            spdlog::error("Sprite::Create: spriteSheet must not be null");
-            return nullptr;
-        }
-        if (spriteSheet->GetFrameCount() <= 0) {
-            spdlog::error("Sprite::Create: spriteSheet has no frames");
-            return nullptr;
-        }
-        return std::unique_ptr<Sprite>(new Sprite(std::move(spriteSheet)));
-    }
-
     Sprite::Sprite(std::shared_ptr<SpriteSheet> spriteSheet)
         : m_spriteSheet(std::move(spriteSheet)) {
     }

--- a/src/graphics/sprite.cpp
+++ b/src/graphics/sprite.cpp
@@ -132,7 +132,7 @@ namespace moth_graphics::graphics {
         return m_spriteSheet->GetImage();
     }
 
-    void DrawSprite(IGraphics& graphics, Sprite& sprite, IntRect const& destRect) {
+    void DrawSprite(IGraphics& graphics, Sprite const& sprite, IntRect const& destRect) {
         auto const& image = sprite.GetImage();
         if (image) {
             auto const frameRect = sprite.GetCurrentFrameRect();
@@ -140,7 +140,7 @@ namespace moth_graphics::graphics {
         }
     }
 
-    void DrawSprite(IGraphics& graphics, Sprite& sprite, IntVec2 const& pos, FloatVec2 const& pivot) {
+    void DrawSprite(IGraphics& graphics, Sprite const& sprite, IntVec2 const& pos, FloatVec2 const& pivot) {
         auto const& image = sprite.GetImage();
         if (image) {
             auto const frameRect = sprite.GetCurrentFrameRect();
@@ -153,7 +153,7 @@ namespace moth_graphics::graphics {
         }
     }
 
-    void DrawSprite(IGraphics& graphics, Sprite& sprite, IntVec2 const& pos) {
+    void DrawSprite(IGraphics& graphics, Sprite const& sprite, IntVec2 const& pos) {
         auto const& image = sprite.GetImage();
         if (image) {
             auto const frameRect = sprite.GetCurrentFrameRect();

--- a/src/graphics/sprite.cpp
+++ b/src/graphics/sprite.cpp
@@ -1,5 +1,6 @@
 #include "common.h"
 #include "moth_graphics/graphics/sprite.h"
+#include "moth_graphics/graphics/igraphics.h"
 
 namespace moth_graphics::graphics {
     std::unique_ptr<Sprite> Sprite::Create(std::shared_ptr<SpriteSheet> spriteSheet) {
@@ -129,5 +130,40 @@ namespace moth_graphics::graphics {
 
     Image const& Sprite::GetImage() const {
         return m_spriteSheet->GetImage();
+    }
+
+    void DrawSprite(IGraphics& graphics, Sprite& sprite, IntRect const& destRect) {
+        auto const& image = sprite.GetImage();
+        if (image) {
+            auto const frameRect = sprite.GetCurrentFrameRect();
+            graphics.DrawImage(image, destRect, &frameRect);
+        }
+    }
+
+    void DrawSprite(IGraphics& graphics, Sprite& sprite, IntVec2 const& pos, FloatVec2 const& pivot) {
+        auto const& image = sprite.GetImage();
+        if (image) {
+            auto const frameRect = sprite.GetCurrentFrameRect();
+            IntRect const destRect = MakeRect(
+                pos.x - static_cast<int>(pivot.x * static_cast<float>(frameRect.w())),
+                pos.y - static_cast<int>(pivot.y * static_cast<float>(frameRect.h())),
+                frameRect.w(),
+                frameRect.h());
+            graphics.DrawImage(image, destRect, &frameRect);
+        }
+    }
+
+    void DrawSprite(IGraphics& graphics, Sprite& sprite, IntVec2 const& pos) {
+        auto const& image = sprite.GetImage();
+        if (image) {
+            auto const frameRect = sprite.GetCurrentFrameRect();
+            auto const framePivot = sprite.GetCurrentFramePivot();
+            IntRect const destRect = MakeRect(
+                pos.x - framePivot.x,
+                pos.y - framePivot.y,
+                frameRect.w(),
+                frameRect.h());
+            graphics.DrawImage(image, destRect, &frameRect);
+        }
     }
 }

--- a/tests/src/api_surface_sprite.cpp
+++ b/tests/src/api_surface_sprite.cpp
@@ -1,6 +1,7 @@
 // Pins the method signatures of SpriteSheet and Sprite.
 
 #include "moth_graphics/moth_graphics.h"
+#include "moth_graphics/graphics/sprite.h"
 
 #include <catch2/catch_all.hpp>
 #include <memory>

--- a/tests/src/test_sprite.cpp
+++ b/tests/src/test_sprite.cpp
@@ -46,20 +46,10 @@ namespace {
 // Construction
 // ---------------------------------------------------------------------------
 
-TEST_CASE("Sprite::Create returns nullptr for null sheet", "[sprite][create]") {
-    REQUIRE(Sprite::Create(nullptr) == nullptr);
-}
-
-TEST_CASE("Sprite::Create returns nullptr for empty sheet", "[sprite][create]") {
-    auto sheet = std::make_shared<SpriteSheet>(Image{},
-                                               std::vector<SpriteSheet::FrameEntry>{},
-                                               std::vector<SpriteSheet::ClipEntry>{});
-    REQUIRE(Sprite::Create(sheet) == nullptr);
-}
-
-TEST_CASE("Sprite::Create succeeds for a valid sheet", "[sprite][create]") {
+TEST_CASE("Sprite constructs from a valid sheet", "[sprite][construct]") {
     auto sheet = MakeSheet(2);
-    REQUIRE(Sprite::Create(sheet) != nullptr);
+    Sprite sprite{ sheet };
+    REQUIRE(sprite.GetSpriteSheet().GetFrameCount() == 2);
 }
 
 // ---------------------------------------------------------------------------
@@ -67,15 +57,15 @@ TEST_CASE("Sprite::Create succeeds for a valid sheet", "[sprite][create]") {
 // ---------------------------------------------------------------------------
 
 TEST_CASE("Sprite starts not playing with no clip", "[sprite][initial]") {
-    auto sprite = Sprite::Create(MakeSheet(2));
-    REQUIRE_FALSE(sprite->IsPlaying());
-    REQUIRE(sprite->GetCurrentClipName().empty());
+    Sprite sprite{MakeSheet(2)};
+    REQUIRE_FALSE(sprite.IsPlaying());
+    REQUIRE(sprite.GetCurrentClipName().empty());
 }
 
 TEST_CASE("Sprite starts on atlas frame 0", "[sprite][initial]") {
-    auto sprite = Sprite::Create(MakeSheet(3));
+    Sprite sprite{MakeSheet(3)};
     // No clip active — GetCurrentFrame() returns the raw atlas index.
-    REQUIRE(sprite->GetCurrentFrame() == 0);
+    REQUIRE(sprite.GetCurrentFrame() == 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -86,39 +76,39 @@ TEST_CASE("SetClip selects a valid clip without changing playing state", "[sprit
     auto sheet = MakeSheet(2, {
         MakeClipEntry("run", { { 0, 100 }, { 1, 100 } })
     });
-    auto sprite = Sprite::Create(sheet);
+    Sprite sprite{sheet};
 
     // Initially not playing; SetClip should leave it not playing.
-    sprite->SetClip("run");
-    REQUIRE(sprite->GetCurrentClipName() == "run");
-    REQUIRE_FALSE(sprite->IsPlaying());
+    sprite.SetClip("run");
+    REQUIRE(sprite.GetCurrentClipName() == "run");
+    REQUIRE_FALSE(sprite.IsPlaying());
 }
 
 TEST_CASE("SetClip on unknown name clears clip and stops playing", "[sprite][set_clip]") {
     auto sheet = MakeSheet(2, {
         MakeClipEntry("run", { { 0, 100 } })
     });
-    auto sprite = Sprite::Create(sheet);
-    sprite->SetClip("run");
-    sprite->SetPlaying(true);
-    REQUIRE(sprite->IsPlaying());
+    Sprite sprite{sheet};
+    sprite.SetClip("run");
+    sprite.SetPlaying(true);
+    REQUIRE(sprite.IsPlaying());
 
-    sprite->SetClip("nonexistent");
-    REQUIRE(sprite->GetCurrentClipName().empty());
-    REQUIRE_FALSE(sprite->IsPlaying());
+    sprite.SetClip("nonexistent");
+    REQUIRE(sprite.GetCurrentClipName().empty());
+    REQUIRE_FALSE(sprite.IsPlaying());
 }
 
 TEST_CASE("SetClip with empty string clears clip and stops playing", "[sprite][set_clip]") {
     auto sheet = MakeSheet(2, {
         MakeClipEntry("run", { { 0, 100 } })
     });
-    auto sprite = Sprite::Create(sheet);
-    sprite->SetClip("run");
-    sprite->SetPlaying(true);
+    Sprite sprite{sheet};
+    sprite.SetClip("run");
+    sprite.SetPlaying(true);
 
-    sprite->SetClip("");
-    REQUIRE(sprite->GetCurrentClipName().empty());
-    REQUIRE_FALSE(sprite->IsPlaying());
+    sprite.SetClip("");
+    REQUIRE(sprite.GetCurrentClipName().empty());
+    REQUIRE_FALSE(sprite.IsPlaying());
 }
 
 // ---------------------------------------------------------------------------
@@ -126,21 +116,21 @@ TEST_CASE("SetClip with empty string clears clip and stops playing", "[sprite][s
 // ---------------------------------------------------------------------------
 
 TEST_CASE("SetPlaying has no effect without an active clip", "[sprite][set_playing]") {
-    auto sprite = Sprite::Create(MakeSheet(2));
-    sprite->SetPlaying(true);
-    REQUIRE_FALSE(sprite->IsPlaying());
+    Sprite sprite{MakeSheet(2)};
+    sprite.SetPlaying(true);
+    REQUIRE_FALSE(sprite.IsPlaying());
 }
 
 TEST_CASE("SetPlaying resumes after SetClip selects a valid clip", "[sprite][set_playing]") {
     auto sheet = MakeSheet(2, {
         MakeClipEntry("run", { { 0, 100 }, { 1, 100 } })
     });
-    auto sprite = Sprite::Create(sheet);
-    sprite->SetClip("run");
-    sprite->SetPlaying(true);
-    REQUIRE(sprite->IsPlaying());
-    sprite->SetPlaying(false);
-    REQUIRE_FALSE(sprite->IsPlaying());
+    Sprite sprite{sheet};
+    sprite.SetClip("run");
+    sprite.SetPlaying(true);
+    REQUIRE(sprite.IsPlaying());
+    sprite.SetPlaying(false);
+    REQUIRE_FALSE(sprite.IsPlaying());
 }
 
 // ---------------------------------------------------------------------------
@@ -151,64 +141,64 @@ TEST_CASE("Update does not advance frames when not playing", "[sprite][update]")
     auto sheet = MakeSheet(2, {
         MakeClipEntry("idle", { { 0, 100 }, { 1, 100 } })
     });
-    auto sprite = Sprite::Create(sheet);
-    sprite->SetClip("idle");
+    Sprite sprite{sheet};
+    sprite.SetClip("idle");
     // Not playing — Update should be a no-op.
-    sprite->Update(200);
-    REQUIRE(sprite->GetCurrentFrame() == 0);
+    sprite.Update(200);
+    REQUIRE(sprite.GetCurrentFrame() == 0);
 }
 
 TEST_CASE("Update advances to next clip step when duration elapses", "[sprite][update]") {
     auto sheet = MakeSheet(2, {
         MakeClipEntry("run", { { 0, 100 }, { 1, 100 } })
     });
-    auto sprite = Sprite::Create(sheet);
-    sprite->SetClip("run");
-    sprite->SetPlaying(true);
+    Sprite sprite{sheet};
+    sprite.SetClip("run");
+    sprite.SetPlaying(true);
 
-    sprite->Update(100);  // exactly one step duration
+    sprite.Update(100);  // exactly one step duration
     // Should now be on clip step 1, which maps to atlas frame 1.
-    REQUIRE(sprite->GetCurrentFrame() == 1);
-    REQUIRE(sprite->IsPlaying());
+    REQUIRE(sprite.GetCurrentFrame() == 1);
+    REQUIRE(sprite.IsPlaying());
 }
 
 TEST_CASE("LoopType::Stop freezes on last frame and stops playing", "[sprite][loop][stop]") {
     auto sheet = MakeSheet(2, {
         MakeClipEntry("anim", { { 0, 100 }, { 1, 100 } }, SpriteSheet::LoopType::Stop)
     });
-    auto sprite = Sprite::Create(sheet);
-    sprite->SetClip("anim");
-    sprite->SetPlaying(true);
+    Sprite sprite{sheet};
+    sprite.SetClip("anim");
+    sprite.SetPlaying(true);
 
-    sprite->Update(250);  // well past both steps
-    REQUIRE_FALSE(sprite->IsPlaying());
-    REQUIRE(sprite->GetCurrentFrame() == 1);  // frozen on last atlas frame
+    sprite.Update(250);  // well past both steps
+    REQUIRE_FALSE(sprite.IsPlaying());
+    REQUIRE(sprite.GetCurrentFrame() == 1);  // frozen on last atlas frame
 }
 
 TEST_CASE("LoopType::Reset rewinds to frame 0 and stops playing", "[sprite][loop][reset]") {
     auto sheet = MakeSheet(2, {
         MakeClipEntry("anim", { { 0, 100 }, { 1, 100 } }, SpriteSheet::LoopType::Reset)
     });
-    auto sprite = Sprite::Create(sheet);
-    sprite->SetClip("anim");
-    sprite->SetPlaying(true);
+    Sprite sprite{sheet};
+    sprite.SetClip("anim");
+    sprite.SetPlaying(true);
 
-    sprite->Update(250);
-    REQUIRE_FALSE(sprite->IsPlaying());
-    REQUIRE(sprite->GetCurrentFrame() == 0);  // reset to first atlas frame
+    sprite.Update(250);
+    REQUIRE_FALSE(sprite.IsPlaying());
+    REQUIRE(sprite.GetCurrentFrame() == 0);  // reset to first atlas frame
 }
 
 TEST_CASE("LoopType::Loop wraps back to first step and keeps playing", "[sprite][loop][loop]") {
     auto sheet = MakeSheet(2, {
         MakeClipEntry("anim", { { 0, 100 }, { 1, 100 } }, SpriteSheet::LoopType::Loop)
     });
-    auto sprite = Sprite::Create(sheet);
-    sprite->SetClip("anim");
-    sprite->SetPlaying(true);
+    Sprite sprite{sheet};
+    sprite.SetClip("anim");
+    sprite.SetPlaying(true);
 
-    sprite->Update(250);  // past end; wraps: 250-100-100=50ms into step 0
-    REQUIRE(sprite->IsPlaying());
-    REQUIRE(sprite->GetCurrentFrame() == 0);
+    sprite.Update(250);  // past end; wraps: 250-100-100=50ms into step 0
+    REQUIRE(sprite.IsPlaying());
+    REQUIRE(sprite.GetCurrentFrame() == 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -216,25 +206,25 @@ TEST_CASE("LoopType::Loop wraps back to first step and keeps playing", "[sprite]
 // ---------------------------------------------------------------------------
 
 TEST_CASE("SetFrame clamps to valid range", "[sprite][set_frame]") {
-    auto sprite = Sprite::Create(MakeSheet(3));
-    sprite->SetFrame(-1);
-    REQUIRE(sprite->GetCurrentFrame() == 0);
-    sprite->SetFrame(100);
-    REQUIRE(sprite->GetCurrentFrame() == 2);
+    Sprite sprite{MakeSheet(3)};
+    sprite.SetFrame(-1);
+    REQUIRE(sprite.GetCurrentFrame() == 0);
+    sprite.SetFrame(100);
+    REQUIRE(sprite.GetCurrentFrame() == 2);
 }
 
 TEST_CASE("SetFrame clears clip and stops playing", "[sprite][set_frame]") {
     auto sheet = MakeSheet(2, {
         MakeClipEntry("run", { { 0, 100 } })
     });
-    auto sprite = Sprite::Create(sheet);
-    sprite->SetClip("run");
-    sprite->SetPlaying(true);
+    Sprite sprite{sheet};
+    sprite.SetClip("run");
+    sprite.SetPlaying(true);
 
-    sprite->SetFrame(1);
-    REQUIRE_FALSE(sprite->IsPlaying());
-    REQUIRE(sprite->GetCurrentClipName().empty());
-    REQUIRE(sprite->GetCurrentFrame() == 1);
+    sprite.SetFrame(1);
+    REQUIRE_FALSE(sprite.IsPlaying());
+    REQUIRE(sprite.GetCurrentClipName().empty());
+    REQUIRE(sprite.GetCurrentFrame() == 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -245,10 +235,10 @@ TEST_CASE("GetCurrentFrameRect returns the atlas rect for the active frame", "[s
     auto sheet = MakeSheet(2, {
         MakeClipEntry("run", { { 1, 100 } })  // clip step maps to atlas frame 1
     });
-    auto sprite = Sprite::Create(sheet);
-    sprite->SetClip("run");
+    Sprite sprite{sheet};
+    sprite.SetClip("run");
 
-    auto const rect = sprite->GetCurrentFrameRect();
+    auto const rect = sprite.GetCurrentFrameRect();
     // Atlas frame 1 starts at x=8, width=8 (from MakeSheet helper).
     REQUIRE(rect.x() == 8);
     REQUIRE(rect.w() == 8);
@@ -260,10 +250,10 @@ TEST_CASE("GetCurrentFramePivot returns the per-frame pivot", "[sprite][frame_pi
     auto sheet = MakeSheet(3, {
         MakeClipEntry("run", { { 2, 100 } })  // atlas frame 2 -> pivot {2,2}
     });
-    auto sprite = Sprite::Create(sheet);
-    sprite->SetClip("run");
+    Sprite sprite{sheet};
+    sprite.SetClip("run");
 
-    auto const pivot = sprite->GetCurrentFramePivot();
+    auto const pivot = sprite.GetCurrentFramePivot();
     REQUIRE(pivot.x == 2);
     REQUIRE(pivot.y == 2);
 }


### PR DESCRIPTION
## Summary
- Move the three `DrawSprite` overloads from inline methods on `IGraphics` to free functions in `sprite.h`/`sprite.cpp`
- `IGraphics` no longer includes `sprite.h`, so consumers of `igraphics.h` no longer pay the `Sprite`/`SpriteSheet` compile cost

## Test plan
- [ ] moth_graphics tests pass
- [ ] moth_editor compiles (may need `#include "sprite.h"` added where `Sprite` was used via the old transitive include)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored sprite drawing API structure to improve code organization while preserving existing rendering capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->