### PR TITLE
refactor: replace IGraphics PushTransform/PopTransform with SetTransform

### DIFF
--- a/include/moth_graphics/graphics/igraphics.h
+++ b/include/moth_graphics/graphics/igraphics.h
@@ -61,12 +61,9 @@ namespace moth_graphics::graphics {
         /// @brief Fill the entire render target with the current color.
         virtual void Clear() = 0;
 
-        /// @brief Push a transform onto the transform stack. Draw calls will apply the active transform to all coordinates.
+        /// @brief Set the active transform applied to all subsequent draw coordinates.
         /// @param transform Local-to-world transform for subsequent draw calls.
-        virtual void PushTransform(FloatMat4x4 const& transform) = 0;
-
-        /// @brief Pop the top transform, restoring the previous one.
-        virtual void PopTransform() = 0;
+        virtual void SetTransform(FloatMat4x4 const& transform) = 0;
 
         /// @brief Draw an image into a destination rectangle in local space. The active transform is applied.
         /// @param image The image to draw.

--- a/include/moth_graphics/graphics/moth_ui/moth_renderer.h
+++ b/include/moth_graphics/graphics/moth_ui/moth_renderer.h
@@ -44,6 +44,7 @@ namespace moth_graphics::graphics {
         IGraphics& m_graphics;
         std::stack<Color> m_drawColor;
         std::stack<BlendMode> m_blendMode;
+        std::stack<moth_ui::FloatMat4x4> m_transform;
         std::stack<IntRect> m_clip;
         std::stack<moth_ui::TextureFilter> m_textureFilter;
     };

--- a/include/moth_graphics/graphics/sdl/sdl_graphics.h
+++ b/include/moth_graphics/graphics/sdl/sdl_graphics.h
@@ -35,8 +35,7 @@ namespace moth_graphics::graphics::sdl {
         void SetBlendMode(BlendMode mode) override;
         void SetColor(Color const& color) override;
         void Clear() override;
-        void PushTransform(FloatMat4x4 const& transform) override;
-        void PopTransform() override;
+        void SetTransform(FloatMat4x4 const& transform) override;
         void DrawImage(Image const& image, IntVec2 const& pos, FloatVec2 const& pivot) override;
         void DrawImage(Image const& image, IntRect const& destRect, IntRect const* sourceRect) override;
         void DrawImageTiled(Image const& image, IntRect const& destRect, IntRect const* sourceRect, float scale) override;
@@ -60,7 +59,7 @@ namespace moth_graphics::graphics::sdl {
         BlendMode m_blendMode = BlendMode::Replace;
         ITarget* m_currentRenderTarget = nullptr;
         SDL_Window* m_imguiWindow = nullptr;
-        std::stack<FloatMat4x4> m_transformStack;
+        FloatMat4x4 m_currentTransform = FloatMat4x4::Identity();
         SDLTextureRef m_textScratchTexture;
         int m_textScratchWidth = 0;
         int m_textScratchHeight = 0;

--- a/include/moth_graphics/graphics/vulkan/vulkan_graphics.h
+++ b/include/moth_graphics/graphics/vulkan/vulkan_graphics.h
@@ -66,8 +66,7 @@ namespace moth_graphics::graphics::vulkan {
         void SetBlendMode(BlendMode mode) override;
         void SetColor(Color const& color) override;
         void Clear() override;
-        void PushTransform(FloatMat4x4 const& transform) override;
-        void PopTransform() override;
+        void SetTransform(FloatMat4x4 const& transform) override;
         void DrawImage(Image const& image, IntVec2 const& pos, FloatVec2 const& pivot) override;
         void DrawImage(Image const& image, IntRect const& destRect, IntRect const* sourceRect) override;
         void DrawImageTiled(Image const& image, IntRect const& destRect, IntRect const* sourceRect, float scale) override;
@@ -104,7 +103,7 @@ namespace moth_graphics::graphics::vulkan {
         bool m_imguiInitialized = false;
         SurfaceContext& m_surfaceContext;
         VkSurfaceKHR m_vkSurface = VK_NULL_HANDLE;
-        std::stack<FloatMat4x4> m_transformStack;
+        FloatMat4x4 m_currentTransform = FloatMat4x4::Identity();
 
         struct PushConstants {
             FloatVec2 xyScale;

--- a/src/graphics/moth_ui/moth_renderer.cpp
+++ b/src/graphics/moth_ui/moth_renderer.cpp
@@ -16,6 +16,7 @@ namespace moth_graphics::graphics {
         : m_graphics(graphics) {
         m_drawColor.push({ 1.0f, 1.0f, 1.0f, 1.0f });
         m_blendMode.push(BlendMode::Replace);
+        m_transform.push(moth_ui::FloatMat4x4::Identity());
         m_textureFilter.push(moth_ui::TextureFilter::Linear);
     }
 
@@ -52,11 +53,16 @@ namespace moth_graphics::graphics {
     }
 
     void MothRenderer::PushTransform(moth_ui::FloatMat4x4 const& transform) {
-        m_graphics.PushTransform(transform);
+        auto const combined = m_transform.top() * transform;
+        m_transform.push(combined);
+        m_graphics.SetTransform(combined);
     }
 
     void MothRenderer::PopTransform() {
-        m_graphics.PopTransform();
+        if (m_transform.size() > 1) {
+            m_transform.pop();
+            m_graphics.SetTransform(m_transform.top());
+        }
     }
 
     void MothRenderer::PushClip(moth_ui::IntRect const& rect) {

--- a/src/graphics/moth_ui/moth_renderer.cpp
+++ b/src/graphics/moth_ui/moth_renderer.cpp
@@ -17,6 +17,7 @@ namespace moth_graphics::graphics {
         m_drawColor.push({ 1.0f, 1.0f, 1.0f, 1.0f });
         m_blendMode.push(BlendMode::Replace);
         m_transform.push(moth_ui::FloatMat4x4::Identity());
+        m_graphics.SetTransform(m_transform.top());
         m_textureFilter.push(moth_ui::TextureFilter::Linear);
     }
 

--- a/src/graphics/sdl/sdl_graphics.cpp
+++ b/src/graphics/sdl/sdl_graphics.cpp
@@ -69,20 +69,11 @@ namespace moth_graphics::graphics::sdl {
     }
 
     FloatMat4x4 Graphics::CurrentTransform() const {
-        if (m_transformStack.empty()) {
-            return FloatMat4x4::Identity();
-        }
-        return m_transformStack.top();
+        return m_currentTransform;
     }
 
-    void Graphics::PushTransform(FloatMat4x4 const& transform) {
-        m_transformStack.push(transform);
-    }
-
-    void Graphics::PopTransform() {
-        if (!m_transformStack.empty()) {
-            m_transformStack.pop();
-        }
+    void Graphics::SetTransform(FloatMat4x4 const& transform) {
+        m_currentTransform = transform;
     }
 
     void Graphics::DrawImage(Image const& image, IntVec2 const& pos, FloatVec2 const& pivot) {

--- a/src/graphics/vulkan/vulkan_graphics.cpp
+++ b/src/graphics/vulkan/vulkan_graphics.cpp
@@ -131,20 +131,11 @@ namespace moth_graphics::graphics::vulkan {
     }
 
     FloatMat4x4 Graphics::CurrentTransform() const {
-        if (m_transformStack.empty()) {
-            return FloatMat4x4::Identity();
-        }
-        return m_transformStack.top();
+        return m_currentTransform;
     }
 
-    void Graphics::PushTransform(FloatMat4x4 const& transform) {
-        m_transformStack.push(transform);
-    }
-
-    void Graphics::PopTransform() {
-        if (!m_transformStack.empty()) {
-            m_transformStack.pop();
-        }
+    void Graphics::SetTransform(FloatMat4x4 const& transform) {
+        m_currentTransform = transform;
     }
 
     void Graphics::DrawImage(Image const& image, IntVec2 const& pos, FloatVec2 const& pivot) {

--- a/tests/src/api_surface_graphics.cpp
+++ b/tests/src/api_surface_graphics.cpp
@@ -19,8 +19,7 @@ TEST_CASE("IGraphics method signatures are stable", "[api][graphics][igraphics]"
     void (IGraphics::*setBlend)(BlendMode)                    = &IGraphics::SetBlendMode;
     void (IGraphics::*setColor)(Color const&)                 = &IGraphics::SetColor;
     void (IGraphics::*clear)()                                = &IGraphics::Clear;
-    void (IGraphics::*pushXform)(FloatMat4x4 const&)          = &IGraphics::PushTransform;
-    void (IGraphics::*popXform)()                             = &IGraphics::PopTransform;
+    void (IGraphics::*setXform)(FloatMat4x4 const&)           = &IGraphics::SetTransform;
     void (IGraphics::*drawImg)(Image const&, IntRect const&,
                                IntRect const*)                = &IGraphics::DrawImage;
     void (IGraphics::*drawImgPivot)(Image const&, IntVec2 const&,
@@ -44,7 +43,7 @@ TEST_CASE("IGraphics method signatures are stable", "[api][graphics][igraphics]"
 
     (void)initImgui; (void)getSurface; (void)begin; (void)end;
     (void)setBlend; (void)setColor; (void)clear;
-    (void)pushXform; (void)popXform;
+    (void)setXform;
     (void)drawImg; (void)drawImgPivot; (void)drawImgTiled;
     (void)drawRect; (void)drawFill; (void)drawLine; (void)drawText;
     (void)setClip; (void)createTarget; (void)getTarget; (void)setTarget;


### PR DESCRIPTION
## Summary
- Replace `PushTransform`/`PopTransform` on `IGraphics` with `SetTransform`
- Move the transform stack into `MothRenderer` alongside the existing color/blend/clip stacks
- IGraphics is now a pure sticky-setter interface: `SetColor`, `SetBlendMode`, `SetClip`, `SetTransform`

## Test plan
- [ ] moth_graphics tests pass (both backends)
- [ ] moth_editor compiles and runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Graphics transform control API refactored across all implementations: replaced stack-based transform methods with a unified SetTransform method in the base interface and all backend renderers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->