### PR TITLE
feat: add font metrics to IFont, switch SpriteSheet getters to std::optional

### DIFF
--- a/include/moth_graphics/graphics/ifont.h
+++ b/include/moth_graphics/graphics/ifont.h
@@ -17,5 +17,14 @@ namespace moth_graphics::graphics {
         /// @param text UTF-8 text to measure.
         /// @return Width and height in pixels.
         virtual IntVec2 Measure(std::string_view text) const = 0;
+
+        /// @brief Returns the distance between consecutive baselines in pixels.
+        virtual int GetLineHeight() const = 0;
+
+        /// @brief Returns the distance from the baseline to the top of the tallest glyph in pixels.
+        virtual int GetAscent() const = 0;
+
+        /// @brief Returns the distance from the baseline to the bottom of the lowest descender in pixels.
+        virtual int GetDescent() const = 0;
     };
 }

--- a/include/moth_graphics/graphics/sdl/sdl_font.h
+++ b/include/moth_graphics/graphics/sdl/sdl_font.h
@@ -16,6 +16,9 @@ namespace moth_graphics::graphics::sdl {
         CachedFontRef GetFontObj() const { return m_fontObj; }
 
         IntVec2 Measure(std::string_view text) const override;
+        int GetLineHeight() const override;
+        int GetAscent() const override;
+        int GetDescent() const override;
 
         static std::unique_ptr<IFont> Load(SDL_Renderer& renderer, const std::filesystem::path& path, int size);
 

--- a/include/moth_graphics/graphics/spritesheet.h
+++ b/include/moth_graphics/graphics/spritesheet.h
@@ -4,6 +4,7 @@
 #include "moth_graphics/utils/rect.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -67,9 +68,8 @@ namespace moth_graphics::graphics {
         /// @brief Returns the total number of frames in the atlas.
         int GetFrameCount() const;
 
-        /// @brief Populates @p outEntry with the frame at @p index.
-        /// @return @c true if the index is valid, @c false otherwise.
-        bool GetFrameDesc(int index, FrameEntry& outEntry) const;
+        /// @brief Returns the frame at @p index, or @c std::nullopt if out of range.
+        std::optional<FrameEntry> GetFrameDesc(int index) const;
 
         /// @brief Returns the number of named clips.
         int GetClipCount() const;
@@ -77,9 +77,8 @@ namespace moth_graphics::graphics {
         /// @brief Returns the clip name at @p index, or empty if out of range.
         std::string_view GetClipName(int index) const;
 
-        /// @brief Looks up a clip by name.
-        /// @return @c true if found, @c false otherwise.
-        bool GetClipDesc(std::string_view name, ClipDesc& outDesc) const;
+        /// @brief Looks up a clip by name, or @c std::nullopt if not found.
+        std::optional<ClipDesc> GetClipDesc(std::string_view name) const;
 
     private:
         Image m_image;

--- a/include/moth_graphics/graphics/vulkan/vulkan_font.h
+++ b/include/moth_graphics/graphics/vulkan/vulkan_font.h
@@ -31,9 +31,9 @@ namespace moth_graphics::graphics::vulkan {
 
         IntVec2 Measure(std::string_view text) const override;
 
-        int32_t GetLineHeight() const { return m_lineHeight; }
-        int32_t GetAscent() const { return m_ascent; }
-        int32_t GetDescent() const { return m_descent; }
+        int32_t GetLineHeight() const override { return m_lineHeight; }
+        int32_t GetAscent() const override { return m_ascent; }
+        int32_t GetDescent() const override { return m_descent; }
         int32_t GetUnderline() const { return m_underline; }
 
         IntVec2 const& GetGlyphBearing(int glyphIndex) const;

--- a/include/moth_graphics/graphics/vulkan/vulkan_font.h
+++ b/include/moth_graphics/graphics/vulkan/vulkan_font.h
@@ -31,9 +31,9 @@ namespace moth_graphics::graphics::vulkan {
 
         IntVec2 Measure(std::string_view text) const override;
 
-        int32_t GetLineHeight() const override { return m_lineHeight; }
-        int32_t GetAscent() const override { return m_ascent; }
-        int32_t GetDescent() const override { return m_descent; }
+        int GetLineHeight() const override { return m_lineHeight; }
+        int GetAscent() const override { return m_ascent; }
+        int GetDescent() const override { return m_descent; }
         int32_t GetUnderline() const { return m_underline; }
 
         IntVec2 const& GetGlyphBearing(int glyphIndex) const;

--- a/src/graphics/moth_ui/moth_flipbook.cpp
+++ b/src/graphics/moth_ui/moth_flipbook.cpp
@@ -27,12 +27,12 @@ namespace moth_graphics::graphics {
     }
 
     bool MothFlipbook::GetFrameDesc(int index, moth_ui::IFlipbook::FrameDesc& outDesc) const {
-        graphics::SpriteSheet::FrameEntry entry;
-        if (!m_spriteSheet->GetFrameDesc(index, entry)) {
+        auto entry = m_spriteSheet->GetFrameDesc(index);
+        if (!entry) {
             return false;
         }
-        outDesc.rect  = entry.rect;
-        outDesc.pivot = entry.pivot;
+        outDesc.rect  = entry->rect;
+        outDesc.pivot = entry->pivot;
         return true;
     }
 
@@ -45,14 +45,14 @@ namespace moth_graphics::graphics {
     }
 
     bool MothFlipbook::GetClipDesc(std::string_view name, moth_ui::IFlipbook::ClipDesc& outDesc) const {
-        graphics::SpriteSheet::ClipDesc internal;
-        if (!m_spriteSheet->GetClipDesc(name, internal)) {
+        auto internal = m_spriteSheet->GetClipDesc(name);
+        if (!internal) {
             return false;
         }
-        outDesc.loop = ToMothLoopType(internal.loop);
+        outDesc.loop = ToMothLoopType(internal->loop);
         outDesc.frames.clear();
-        outDesc.frames.reserve(internal.frames.size());
-        for (auto const& step : internal.frames) {
+        outDesc.frames.reserve(internal->frames.size());
+        for (auto const& step : internal->frames) {
             moth_ui::IFlipbook::ClipFrame f;
             f.frameIndex = step.frameIndex;
             f.durationMs = step.durationMs;

--- a/src/graphics/sdl/sdl_font.cpp
+++ b/src/graphics/sdl/sdl_font.cpp
@@ -16,6 +16,18 @@ namespace moth_graphics::graphics::sdl {
         };
     }
 
+    int Font::GetLineHeight() const {
+        return static_cast<int>(FC_GetLineHeight(m_fontObj.get()));
+    }
+
+    int Font::GetAscent() const {
+        return FC_GetAscent(m_fontObj.get(), "%s", " "); // NOLINT(cppcoreguidelines-pro-type-vararg)
+    }
+
+    int Font::GetDescent() const {
+        return FC_GetDescent(m_fontObj.get(), "%s", " "); // NOLINT(cppcoreguidelines-pro-type-vararg)
+    }
+
     std::unique_ptr<IFont> Font::Load(SDL_Renderer& renderer, const std::filesystem::path& path, int size) {
         SDL_Color defaultColor{ 0x00, 0x00, 0x00, 0xFF };
         return std::make_unique<Font>(CreateCachedFontRef(&renderer, path.string().c_str(), size, defaultColor, TTF_STYLE_NORMAL));

--- a/src/graphics/sdl/sdl_font.cpp
+++ b/src/graphics/sdl/sdl_font.cpp
@@ -21,11 +21,11 @@ namespace moth_graphics::graphics::sdl {
     }
 
     int Font::GetAscent() const {
-        return FC_GetAscent(m_fontObj.get(), "%s", " "); // NOLINT(cppcoreguidelines-pro-type-vararg)
+        return FC_GetAscent(m_fontObj.get(), nullptr);
     }
 
     int Font::GetDescent() const {
-        return FC_GetDescent(m_fontObj.get(), "%s", " "); // NOLINT(cppcoreguidelines-pro-type-vararg)
+        return FC_GetDescent(m_fontObj.get(), nullptr);
     }
 
     std::unique_ptr<IFont> Font::Load(SDL_Renderer& renderer, const std::filesystem::path& path, int size) {

--- a/src/graphics/sdl/sdl_font.cpp
+++ b/src/graphics/sdl/sdl_font.cpp
@@ -21,11 +21,11 @@ namespace moth_graphics::graphics::sdl {
     }
 
     int Font::GetAscent() const {
-        return FC_GetAscent(m_fontObj.get(), nullptr);
+        return FC_GetAscent(m_fontObj.get(), nullptr); // NOLINT(cppcoreguidelines-pro-type-vararg)
     }
 
     int Font::GetDescent() const {
-        return FC_GetDescent(m_fontObj.get(), nullptr);
+        return FC_GetDescent(m_fontObj.get(), nullptr); // NOLINT(cppcoreguidelines-pro-type-vararg)
     }
 
     std::unique_ptr<IFont> Font::Load(SDL_Renderer& renderer, const std::filesystem::path& path, int size) {

--- a/src/graphics/sprite.cpp
+++ b/src/graphics/sprite.cpp
@@ -101,19 +101,13 @@ namespace moth_graphics::graphics {
     }
 
     int Sprite::GetWidth() const {
-        auto entry = m_spriteSheet->GetFrameDesc(GetCurrentFrame());
-        if (entry) {
-            return entry->rect.bottomRight.x - entry->rect.topLeft.x;
-        }
-        return 0;
+        auto const rect = GetCurrentFrameRect();
+        return rect.bottomRight.x - rect.topLeft.x;
     }
 
     int Sprite::GetHeight() const {
-        auto entry = m_spriteSheet->GetFrameDesc(GetCurrentFrame());
-        if (entry) {
-            return entry->rect.bottomRight.y - entry->rect.topLeft.y;
-        }
-        return 0;
+        auto const rect = GetCurrentFrameRect();
+        return rect.bottomRight.y - rect.topLeft.y;
     }
 
     Image const& Sprite::GetImage() const {

--- a/src/graphics/sprite.cpp
+++ b/src/graphics/sprite.cpp
@@ -18,9 +18,9 @@ namespace moth_graphics::graphics {
             return;
         }
 
-        SpriteSheet::ClipDesc clipDesc;
-        if (m_spriteSheet->GetClipDesc(name, clipDesc)) {
-            m_currentClip = std::move(clipDesc);
+        auto clipDesc = m_spriteSheet->GetClipDesc(name);
+        if (clipDesc) {
+            m_currentClip = std::move(*clipDesc);
             m_currentClipName = name;
         } else {
             spdlog::warn("Sprite::SetClip: clip '{}' not found", name);
@@ -85,33 +85,33 @@ namespace moth_graphics::graphics {
     }
 
     IntRect Sprite::GetCurrentFrameRect() const {
-        SpriteSheet::FrameEntry entry;
-        if (m_spriteSheet->GetFrameDesc(GetCurrentFrame(), entry)) {
-            return entry.rect;
+        auto entry = m_spriteSheet->GetFrameDesc(GetCurrentFrame());
+        if (entry) {
+            return entry->rect;
         }
         return {};
     }
 
     IntVec2 Sprite::GetCurrentFramePivot() const {
-        SpriteSheet::FrameEntry entry;
-        if (m_spriteSheet->GetFrameDesc(GetCurrentFrame(), entry)) {
-            return entry.pivot;
+        auto entry = m_spriteSheet->GetFrameDesc(GetCurrentFrame());
+        if (entry) {
+            return entry->pivot;
         }
         return {};
     }
 
     int Sprite::GetWidth() const {
-        SpriteSheet::FrameEntry entry;
-        if (m_spriteSheet->GetFrameDesc(GetCurrentFrame(), entry)) {
-            return entry.rect.bottomRight.x - entry.rect.topLeft.x;
+        auto entry = m_spriteSheet->GetFrameDesc(GetCurrentFrame());
+        if (entry) {
+            return entry->rect.bottomRight.x - entry->rect.topLeft.x;
         }
         return 0;
     }
 
     int Sprite::GetHeight() const {
-        SpriteSheet::FrameEntry entry;
-        if (m_spriteSheet->GetFrameDesc(GetCurrentFrame(), entry)) {
-            return entry.rect.bottomRight.y - entry.rect.topLeft.y;
+        auto entry = m_spriteSheet->GetFrameDesc(GetCurrentFrame());
+        if (entry) {
+            return entry->rect.bottomRight.y - entry->rect.topLeft.y;
         }
         return 0;
     }

--- a/src/graphics/spritesheet.cpp
+++ b/src/graphics/spritesheet.cpp
@@ -1,6 +1,8 @@
 #include "common.h"
 #include "moth_graphics/graphics/spritesheet.h"
 
+#include <optional>
+
 namespace moth_graphics::graphics {
     SpriteSheet::SpriteSheet(Image image,
                              std::vector<FrameEntry> frames,
@@ -18,12 +20,11 @@ namespace moth_graphics::graphics {
         return static_cast<int>(m_frames.size());
     }
 
-    bool SpriteSheet::GetFrameDesc(int index, FrameEntry& outEntry) const {
+    std::optional<SpriteSheet::FrameEntry> SpriteSheet::GetFrameDesc(int index) const {
         if (index < 0 || index >= static_cast<int>(m_frames.size())) {
-            return false;
+            return std::nullopt;
         }
-        outEntry = m_frames[static_cast<size_t>(index)];
-        return true;
+        return m_frames[static_cast<size_t>(index)];
     }
 
     int SpriteSheet::GetClipCount() const {
@@ -37,13 +38,12 @@ namespace moth_graphics::graphics {
         return m_clips[static_cast<size_t>(index)].name;
     }
 
-    bool SpriteSheet::GetClipDesc(std::string_view name, ClipDesc& outDesc) const {
+    std::optional<SpriteSheet::ClipDesc> SpriteSheet::GetClipDesc(std::string_view name) const {
         for (auto const& entry : m_clips) {
             if (entry.name == name) {
-                outDesc = entry.desc;
-                return true;
+                return entry.desc;
             }
         }
-        return false;
+        return std::nullopt;
     }
 }

--- a/tests/src/api_surface_graphics.cpp
+++ b/tests/src/api_surface_graphics.cpp
@@ -67,7 +67,10 @@ TEST_CASE("Image method signatures are stable", "[api][graphics][image]") {
 
 TEST_CASE("IFont method signatures are stable", "[api][graphics][ifont]") {
     IntVec2 (IFont::*measure)(std::string_view) const = &IFont::Measure;
-    (void)measure;
+    int (IFont::*lineHeight)() const                 = &IFont::GetLineHeight;
+    int (IFont::*ascent)() const                     = &IFont::GetAscent;
+    int (IFont::*descent)() const                    = &IFont::GetDescent;
+    (void)measure; (void)lineHeight; (void)ascent; (void)descent;
     SUCCEED();
 }
 

--- a/tests/src/api_surface_sprite.cpp
+++ b/tests/src/api_surface_sprite.cpp
@@ -25,11 +25,10 @@ TEST_CASE("SpriteSheet method signatures are stable", "[api][sprite][spritesheet
     // Method signatures
     Image const& (SpriteSheet::*getImg)() const                                      = &SpriteSheet::GetImage;
     int  (SpriteSheet::*getFrameCount)() const                                       = &SpriteSheet::GetFrameCount;
-    bool (SpriteSheet::*getFrameDesc)(int, SpriteSheet::FrameEntry&) const           = &SpriteSheet::GetFrameDesc;
+    std::optional<SpriteSheet::FrameEntry> (SpriteSheet::*getFrameDesc)(int) const   = &SpriteSheet::GetFrameDesc;
     int  (SpriteSheet::*getClipCount)() const                                        = &SpriteSheet::GetClipCount;
     std::string_view (SpriteSheet::*getClipName)(int) const                          = &SpriteSheet::GetClipName;
-    bool (SpriteSheet::*getClipDesc)(std::string_view,
-                                     SpriteSheet::ClipDesc&) const                  = &SpriteSheet::GetClipDesc;
+    std::optional<SpriteSheet::ClipDesc> (SpriteSheet::*getClipDesc)(std::string_view) const = &SpriteSheet::GetClipDesc;
 
     (void)getImg; (void)getFrameCount; (void)getFrameDesc;
     (void)getClipCount; (void)getClipName; (void)getClipDesc;

--- a/tests/src/test_spritesheet.cpp
+++ b/tests/src/test_spritesheet.cpp
@@ -44,22 +44,21 @@ TEST_CASE("SpriteSheet reports correct frame count", "[spritesheet]") {
 TEST_CASE("SpriteSheet GetFrameDesc returns correct rect and pivot", "[spritesheet]") {
     SpriteSheet sheet(MakeDummyImage(), { MakeFrame(4, 8, 32, 16, 5, 3) }, {});
 
-    SpriteSheet::FrameEntry entry{};
-    REQUIRE(sheet.GetFrameDesc(0, entry));
-    REQUIRE(entry.rect.x() == 4);
-    REQUIRE(entry.rect.y() == 8);
-    REQUIRE(entry.rect.w() == 32);
-    REQUIRE(entry.rect.h() == 16);
-    REQUIRE(entry.pivot.x == 5);
-    REQUIRE(entry.pivot.y == 3);
+    auto entry = sheet.GetFrameDesc(0);
+    REQUIRE(entry.has_value());
+    REQUIRE(entry->rect.x() == 4);
+    REQUIRE(entry->rect.y() == 8);
+    REQUIRE(entry->rect.w() == 32);
+    REQUIRE(entry->rect.h() == 16);
+    REQUIRE(entry->pivot.x == 5);
+    REQUIRE(entry->pivot.y == 3);
 }
 
 TEST_CASE("SpriteSheet GetFrameDesc returns false for out-of-range index", "[spritesheet]") {
     SpriteSheet sheet(MakeDummyImage(), { MakeFrame(0, 0, 8, 8) }, {});
 
-    SpriteSheet::FrameEntry entry{};
-    REQUIRE_FALSE(sheet.GetFrameDesc(-1, entry));
-    REQUIRE_FALSE(sheet.GetFrameDesc(1, entry));
+    REQUIRE_FALSE(sheet.GetFrameDesc(-1).has_value());
+    REQUIRE_FALSE(sheet.GetFrameDesc(1).has_value());
 }
 
 TEST_CASE("SpriteSheet reports correct clip count", "[spritesheet]") {
@@ -89,20 +88,19 @@ TEST_CASE("SpriteSheet GetClipDesc returns correct clip data", "[spritesheet]") 
     };
     SpriteSheet sheet(MakeDummyImage(), { MakeFrame(0, 0, 8, 8), MakeFrame(8, 0, 8, 8) }, clips);
 
-    SpriteSheet::ClipDesc desc{};
-    REQUIRE(sheet.GetClipDesc("walk", desc));
-    REQUIRE(desc.loop == SpriteSheet::LoopType::Loop);
-    REQUIRE(desc.frames.size() == 2);
-    REQUIRE(desc.frames[0].frameIndex == 0);
-    REQUIRE(desc.frames[0].durationMs == 80);
-    REQUIRE(desc.frames[1].frameIndex == 1);
-    REQUIRE(desc.frames[1].durationMs == 120);
+    auto desc = sheet.GetClipDesc("walk");
+    REQUIRE(desc.has_value());
+    REQUIRE(desc->loop == SpriteSheet::LoopType::Loop);
+    REQUIRE(desc->frames.size() == 2);
+    REQUIRE(desc->frames[0].frameIndex == 0);
+    REQUIRE(desc->frames[0].durationMs == 80);
+    REQUIRE(desc->frames[1].frameIndex == 1);
+    REQUIRE(desc->frames[1].durationMs == 120);
 }
 
 TEST_CASE("SpriteSheet GetClipDesc returns false for unknown clip name", "[spritesheet]") {
     SpriteSheet sheet(MakeDummyImage(), { MakeFrame(0, 0, 8, 8) }, {});
-    SpriteSheet::ClipDesc desc{};
-    REQUIRE_FALSE(sheet.GetClipDesc("missing", desc));
+    REQUIRE_FALSE(sheet.GetClipDesc("missing").has_value());
 }
 
 TEST_CASE("SpriteSheet GetImage returns the image passed at construction", "[spritesheet]") {


### PR DESCRIPTION
## Summary
- Add `GetLineHeight`, `GetAscent`, `GetDescent` to `IFont` interface
- Implement in SDL (via SDL_FontCache) and Vulkan backends
- Convert `SpriteSheet::GetFrameDesc` and `GetClipDesc` from `bool`+out-param to `std::optional<T>` return

## Test plan
- [ ] moth_graphics tests pass
- [ ] moth_editor compiles against this branch (has companion changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Font now provides direct access to baseline metrics including line height, ascent, and descent.

* **Refactor**
  * SpriteSheet lookup methods now return optional values instead of boolean returns with output parameters, simplifying null-case handling.

* **Tests**
  * Updated API surface and unit tests to validate new font metrics methods and SpriteSheet API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->