### PR TITLE
chore: review lifecycle cleanup — Context interface, private handlers, public LayerStack

### DIFF
--- a/include/moth_graphics/graphics/context.h
+++ b/include/moth_graphics/graphics/context.h
@@ -4,5 +4,8 @@ namespace moth_graphics::graphics {
     class Context {
     public:
         virtual ~Context() = default;
+
+        virtual bool Startup() = 0;
+        virtual void Shutdown() = 0;
     };
 }

--- a/include/moth_graphics/graphics/sdl/sdl_context.h
+++ b/include/moth_graphics/graphics/sdl/sdl_context.h
@@ -7,5 +7,8 @@ namespace moth_graphics::graphics::sdl {
     public:
         Context() = default;
         ~Context() override = default;
+
+        bool Startup() override { return true; }
+        void Shutdown() override {}
     };
 }

--- a/include/moth_graphics/graphics/vulkan/vulkan_context.h
+++ b/include/moth_graphics/graphics/vulkan/vulkan_context.h
@@ -12,8 +12,11 @@ typedef FT_LibraryRec_* FT_Library;
 namespace moth_graphics::graphics::vulkan {
     class Context : public moth_graphics::graphics::Context {
     public:
-        Context();
-        virtual ~Context();
+        Context() = default;
+        ~Context() override = default;
+
+        bool Startup() override;
+        void Shutdown() override;
 
         VkInstance const& GetInstance() const { return m_vkInstance; }
         FT_Library const& GetFTLibrary() const { return m_ftLibrary; }

--- a/include/moth_graphics/platform/application.h
+++ b/include/moth_graphics/platform/application.h
@@ -37,15 +37,6 @@ namespace moth_graphics::platform {
 
         bool OnEvent(moth_ui::Event const& event) override;
 
-        /// @brief Called when the window is resized. Returns @c false by default.
-        bool OnWindowSizeEvent(EventWindowSize const& event);
-
-        /// @brief Called on a quit request (e.g. window close button); stops the loop.
-        bool OnRequestQuitEvent(EventRequestQuit const& event);
-
-        /// @brief Called on a hard quit event; stops the loop.
-        bool OnQuitEvent(EventQuit const& event);
-
         void TickFixed(uint32_t ticks) override;
         void Tick(uint32_t ticks) override;
 
@@ -61,6 +52,11 @@ namespace moth_graphics::platform {
         Application& operator=(Application const&) = delete;
         Application(Application&&) = delete;
         Application& operator=(Application&&) = delete;
+
+    private:
+        bool OnWindowSizeEvent(EventWindowSize const& event);
+        bool OnRequestQuitEvent(EventRequestQuit const& event);
+        bool OnQuitEvent(EventQuit const& event);
 
     protected:
         /// @brief Override to perform setup before the window is created.

--- a/include/moth_graphics/platform/window.h
+++ b/include/moth_graphics/platform/window.h
@@ -75,9 +75,10 @@ namespace moth_graphics::platform {
         // Must be called after PostCreate (i.e. after the native window exists).
         void PushLayer(std::unique_ptr<moth_ui::Layer> layer);
 
-    protected:
-        /// @brief Returns the moth_ui layer stack. Only for internal/platform use.
+        /// @brief Returns the moth_ui layer stack.
         moth_ui::LayerStack& GetLayerStack() const { return *m_layerStack; }
+
+    protected:
         /// @brief Called after the native window and graphics objects are created.
         void PostCreate();
 

--- a/src/graphics/vulkan/vulkan_context.cpp
+++ b/src/graphics/vulkan/vulkan_context.cpp
@@ -80,7 +80,7 @@ namespace {
         ;
 
 namespace moth_graphics::graphics::vulkan {
-    Context::Context() {
+    bool Context::Startup() {
         spdlog::info("Vulkan: initializing context");
 
         spdlog::info("Vulkan: initializing FreeType");
@@ -156,13 +156,15 @@ namespace moth_graphics::graphics::vulkan {
             CHECK_VK_RESULT(CreateDebugUtilsMessengerEXT(m_vkInstance, &createInfo, nullptr, &m_vkDebugMessenger));
         }
         spdlog::info("Vulkan: context ready");
+        return true;
     }
 
-    Context::~Context() {
+    void Context::Shutdown() {
         spdlog::info("Vulkan: destroying context");
         if (enableValidationLayers) {
             DestroyDebugUtilsMessengerEXT(m_vkInstance, m_vkDebugMessenger, nullptr);
         }
         vkDestroyInstance(m_vkInstance, nullptr);
+        FT_Done_FreeType(m_ftLibrary);
     }
 }

--- a/src/platform/glfw/glfw_platform.cpp
+++ b/src/platform/glfw/glfw_platform.cpp
@@ -10,13 +10,21 @@ namespace moth_graphics::platform::glfw {
         }
         spdlog::info("GLFW: initialized");
         m_context = std::make_unique<graphics::vulkan::Context>();
-        return m_context->Startup();
+        if (!m_context->Startup()) {
+            spdlog::error("GLFW: graphics context startup failed");
+            m_context.reset();
+            glfwTerminate();
+            return false;
+        }
+        return true;
     }
 
     void Platform::Shutdown() {
         spdlog::info("GLFW: shutting down");
-        m_context->Shutdown();
-        m_context.reset();
+        if (m_context) {
+            m_context->Shutdown();
+            m_context.reset();
+        }
         glfwTerminate();
     }
     

--- a/src/platform/glfw/glfw_platform.cpp
+++ b/src/platform/glfw/glfw_platform.cpp
@@ -10,11 +10,13 @@ namespace moth_graphics::platform::glfw {
         }
         spdlog::info("GLFW: initialized");
         m_context = std::make_unique<graphics::vulkan::Context>();
-        return true;
+        return m_context->Startup();
     }
 
     void Platform::Shutdown() {
         spdlog::info("GLFW: shutting down");
+        m_context->Shutdown();
+        m_context.reset();
         glfwTerminate();
     }
     

--- a/src/platform/sdl/sdl_platform.cpp
+++ b/src/platform/sdl/sdl_platform.cpp
@@ -20,13 +20,21 @@ namespace moth_graphics::platform::sdl {
         }
         spdlog::info("SDL: initialized");
         m_context = std::make_unique<graphics::sdl::Context>();
-        return m_context->Startup();
+        if (!m_context->Startup()) {
+            spdlog::error("SDL: graphics context startup failed");
+            m_context.reset();
+            SDL_Quit();
+            return false;
+        }
+        return true;
     }
 
     void Platform::Shutdown() {
         spdlog::info("SDL: shutting down");
-        m_context->Shutdown();
-        m_context.reset();
+        if (m_context) {
+            m_context->Shutdown();
+            m_context.reset();
+        }
         SDL_Quit();
     }
 }

--- a/src/platform/sdl/sdl_platform.cpp
+++ b/src/platform/sdl/sdl_platform.cpp
@@ -5,10 +5,6 @@
 
 namespace moth_graphics::platform::sdl {
     graphics::Context& Platform::GetGraphicsContext() {
-        // lazy init this will mean the first window created is linked to this context
-        if (!m_context) {
-            m_context = std::make_unique<graphics::sdl::Context>();
-        }
         return *m_context;
     }
 
@@ -23,11 +19,14 @@ namespace moth_graphics::platform::sdl {
             return false;
         }
         spdlog::info("SDL: initialized");
-        return true;
+        m_context = std::make_unique<graphics::sdl::Context>();
+        return m_context->Startup();
     }
 
     void Platform::Shutdown() {
         spdlog::info("SDL: shutting down");
+        m_context->Shutdown();
+        m_context.reset();
         SDL_Quit();
     }
 }


### PR DESCRIPTION
## Summary
- Give `Context` a real interface with `Startup()`/`Shutdown()` pure virtuals
- Move Vulkan ctor/dtor work into `Startup()`/`Shutdown()`; add missing `FT_Done_FreeType`
- SDL Context gets trivial no-op overrides; eager init replaces lazy init
- Move `Application` event handlers (`OnWindowSizeEvent`, `OnRequestQuitEvent`, `OnQuitEvent`) from public to private — they are dispatch targets called only internally via `EventDispatch`
- Move `Window::GetLayerStack()` from protected to public, giving callers full access to the layer stack API alongside the existing `PushLayer()`

## Test plan
- [ ] CI passes on both Linux and Windows
- [ ] moth_editor builds and runs against this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Graphics contexts now feature explicit `Startup()` and `Shutdown()` lifecycle methods for improved initialization and cleanup control.
  * Window layer stack is now publicly accessible.

* **Refactor**
  * Application event handlers repositioned to private scope for better encapsulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->