### PR TITLE
refactor: RAII wrappers for internal Vulkan handles

### DIFF
--- a/src/graphics/vulkan/vulkan_fence.cpp
+++ b/src/graphics/vulkan/vulkan_fence.cpp
@@ -4,15 +4,13 @@
 
 namespace moth_graphics::graphics::vulkan {
     Fence::Fence(SurfaceContext& context)
-        : m_context(context)
-        , m_vkFence(VK_NULL_HANDLE) {
+        : m_context(context) {
         VkFenceCreateInfo fenceInfo{};
         fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
         fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-        CHECK_VK_RESULT(vkCreateFence(m_context.GetVkDevice(), &fenceInfo, nullptr, &m_vkFence));
-    }
-
-    Fence::~Fence() {
-        vkDestroyFence(m_context.GetVkDevice(), m_vkFence, nullptr);
+        VkFence fence = VK_NULL_HANDLE;
+        CHECK_VK_RESULT(vkCreateFence(m_context.GetVkDevice(), &fenceInfo, nullptr, &fence));
+        VkDevice const device = m_context.GetVkDevice();
+        m_vkFence = UniqueHandle<VkFence>(fence, [device](VkFence h) { vkDestroyFence(device, h, nullptr); });
     }
 }

--- a/src/graphics/vulkan/vulkan_fence.h
+++ b/src/graphics/vulkan/vulkan_fence.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "moth_graphics/graphics/vulkan/vulkan_surface_context.h"
+#include "vulkan_unique.h"
 
 #include <vulkan/vulkan_core.h>
 
@@ -8,12 +9,12 @@ namespace moth_graphics::graphics::vulkan {
     class Fence {
     public:
         Fence(SurfaceContext& context);
-        ~Fence();
+        ~Fence() = default;
 
         VkFence GetVkFence() const { return m_vkFence; }
 
     private:
         SurfaceContext& m_context;
-        VkFence m_vkFence;
+        UniqueHandle<VkFence> m_vkFence;
     };
 }

--- a/src/graphics/vulkan/vulkan_font.cpp
+++ b/src/graphics/vulkan/vulkan_font.cpp
@@ -388,11 +388,12 @@ namespace moth_graphics::graphics::vulkan {
         if (std::end(m_vkDescriptorSets) == it) {
             VkDescriptorSet vkDescriptorSet = VK_NULL_HANDLE;
 
+            VkDescriptorSetLayout const setLayoutHandle = shader.m_descriptorSetLayout.Get();
             VkDescriptorSetAllocateInfo alloc_info{};
             alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
             alloc_info.descriptorPool = shader.m_descriptorPool;
             alloc_info.descriptorSetCount = 1;
-            alloc_info.pSetLayouts = &shader.m_descriptorSetLayout;
+            alloc_info.pSetLayouts = &setLayoutHandle;
             CHECK_VK_RESULT(vkAllocateDescriptorSets(m_context.GetVkDevice(), &alloc_info, &vkDescriptorSet));
 
             VkDescriptorBufferInfo glyph_info[1] = {};

--- a/src/graphics/vulkan/vulkan_framebuffer.cpp
+++ b/src/graphics/vulkan/vulkan_framebuffer.cpp
@@ -29,10 +29,6 @@ namespace moth_graphics::graphics::vulkan {
         m_commandBuffer->SubmitAndWait();
     }
 
-    Framebuffer::~Framebuffer() {
-        vkDestroyFramebuffer(m_context.GetVkDevice(), m_vkFramebuffer, nullptr);
-    }
-
     VkExtent2D Framebuffer::GetVkExtent() const {
         return m_texture->GetVkExtent();
     }
@@ -42,10 +38,10 @@ namespace moth_graphics::graphics::vulkan {
     }
 
     VkSemaphore Framebuffer::GetAvailableSemaphore() const {
-        return m_frameSlot ? m_frameSlot->imageAvailable : VK_NULL_HANDLE;
+        return m_frameSlot ? m_frameSlot->imageAvailable.Get() : VK_NULL_HANDLE;
     }
     VkSemaphore Framebuffer::GetRenderFinishedSemaphore() const {
-        return m_frameSlot ? m_frameSlot->renderFinished : VK_NULL_HANDLE;
+        return m_frameSlot ? m_frameSlot->renderFinished.Get() : VK_NULL_HANDLE;
     }
 
     void Framebuffer::CreateFramebufferResource(VkRenderPass renderPass) {
@@ -59,6 +55,11 @@ namespace moth_graphics::graphics::vulkan {
         info.width = m_texture->GetWidth();
         info.height = m_texture->GetHeight();
         info.layers = 1;
-        CHECK_VK_RESULT(vkCreateFramebuffer(m_context.GetVkDevice(), &info, nullptr, &m_vkFramebuffer));
+        VkFramebuffer framebuffer = VK_NULL_HANDLE;
+        CHECK_VK_RESULT(vkCreateFramebuffer(m_context.GetVkDevice(), &info, nullptr, &framebuffer));
+        VkDevice const device = m_context.GetVkDevice();
+        m_vkFramebuffer = UniqueHandle<VkFramebuffer>(framebuffer, [device](VkFramebuffer h) {
+            vkDestroyFramebuffer(device, h, nullptr);
+        });
     }
 }

--- a/src/graphics/vulkan/vulkan_framebuffer.h
+++ b/src/graphics/vulkan/vulkan_framebuffer.h
@@ -5,6 +5,7 @@
 #include "vulkan_fence.h"
 #include "moth_graphics/graphics/vulkan/vulkan_surface_context.h"
 #include "vulkan_texture.h"
+#include "vulkan_unique.h"
 
 #include <vulkan/vulkan_core.h>
 
@@ -19,7 +20,7 @@ namespace moth_graphics::graphics::vulkan {
     public:
         Framebuffer(SurfaceContext& context, uint32_t width, uint32_t height, VkImage image, VkImageView view, VkFormat format, VkRenderPass renderPass, uint32_t swapchainIndex);
         Framebuffer(SurfaceContext& context, uint32_t width, uint32_t height, VkFormat format, VkImageTiling tiling, VkImageUsageFlags usage, VkRenderPass renderPass);
-        virtual ~Framebuffer();
+        ~Framebuffer() override = default;
 
         int GetWidth() const { return m_texture ? m_texture->GetWidth() : 0; }
         int GetHeight() const { return m_texture ? m_texture->GetHeight() : 0; }
@@ -39,11 +40,13 @@ namespace moth_graphics::graphics::vulkan {
 
     protected:
         SurfaceContext& m_context;
-        VkFramebuffer m_vkFramebuffer = VK_NULL_HANDLE;
         std::unique_ptr<CommandBuffer> m_commandBuffer;
         std::shared_ptr<Texture> m_texture;
         std::unique_ptr<Fence> m_fence;
         std::shared_ptr<FrameSlot> m_frameSlot;
+        // Declared last so it is destroyed first — matches the previous order
+        // where vkDestroyFramebuffer ran before texture/view release.
+        UniqueHandle<VkFramebuffer> m_vkFramebuffer;
 
         uint32_t m_swapchainIndex = 0;
 

--- a/src/graphics/vulkan/vulkan_graphics.cpp
+++ b/src/graphics/vulkan/vulkan_graphics.cpp
@@ -9,15 +9,19 @@
 namespace moth_graphics::graphics::vulkan {
     Graphics::Graphics(SurfaceContext& context, VkSurfaceKHR surface, uint32_t surfaceWidth, uint32_t surfaceHeight)
         : m_surfaceContext(context)
-        , m_vkSurface(surface)
-        , m_vkPipelineCache(VK_NULL_HANDLE) {
+        , m_vkSurface(surface) {
         CreateRenderPass();
         CreateShaders();
         CreateDefaultImage();
 
         VkPipelineCacheCreateInfo cacheInfo{};
         cacheInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
-        CHECK_VK_RESULT(vkCreatePipelineCache(m_surfaceContext.GetVkDevice(), &cacheInfo, nullptr, &m_vkPipelineCache));
+        VkPipelineCache cache = VK_NULL_HANDLE;
+        CHECK_VK_RESULT(vkCreatePipelineCache(m_surfaceContext.GetVkDevice(), &cacheInfo, nullptr, &cache));
+        VkDevice const device = m_surfaceContext.GetVkDevice();
+        m_vkPipelineCache = UniqueHandle<VkPipelineCache>(cache, [device](VkPipelineCache h) {
+            vkDestroyPipelineCache(device, h, nullptr);
+        });
 
         m_swapchain = std::make_unique<Swapchain>(m_surfaceContext, *m_renderPass, surface, VkExtent2D{ surfaceWidth, surfaceHeight });
 
@@ -35,7 +39,6 @@ namespace moth_graphics::graphics::vulkan {
             m_defaultContext.m_vertexBuffer->Unmap();
             m_defaultContext.m_vertexBufferData = nullptr;
         }
-        vkDestroyPipelineCache(m_surfaceContext.GetVkDevice(), m_vkPipelineCache, nullptr);
     }
 
     void Graphics::Begin() {

--- a/src/graphics/vulkan/vulkan_graphics.h
+++ b/src/graphics/vulkan/vulkan_graphics.h
@@ -16,6 +16,7 @@
 #include "moth_graphics/graphics/vulkan/vulkan_surface_context.h"
 #include "vulkan_swapchain.h"
 #include "vulkan_texture.h"
+#include "vulkan_unique.h"
 #include "moth_graphics/platform/window.h"
 #include "moth_graphics/utils/rect.h"
 #include "moth_graphics/utils/vector.h"
@@ -147,7 +148,7 @@ namespace moth_graphics::graphics::vulkan {
             std::optional<PendingBatch> m_pendingBatch;
         };
 
-        VkPipelineCache m_vkPipelineCache;
+        UniqueHandle<VkPipelineCache> m_vkPipelineCache;
         std::map<uint32_t, std::shared_ptr<Pipeline>> m_pipelines;
         std::map<uint32_t, std::shared_ptr<Pipeline>> m_fontPipelines;
         std::unique_ptr<RenderPass> m_renderPass;

--- a/src/graphics/vulkan/vulkan_pipeline.cpp
+++ b/src/graphics/vulkan/vulkan_pipeline.cpp
@@ -6,12 +6,8 @@ namespace moth_graphics::graphics::vulkan {
     Pipeline::Pipeline(uint32_t hash, VkDevice device, VkPipeline pipeline, std::shared_ptr<Shader> shader)
         : m_hash(hash)
         , m_device(device)
-        , m_pipeline(pipeline)
+        , m_pipeline(pipeline, [device](VkPipeline h) { vkDestroyPipeline(device, h, nullptr); })
         , m_shader(shader) {
-    }
-
-    Pipeline::~Pipeline() {
-        vkDestroyPipeline(m_device, m_pipeline, nullptr);
     }
 
     PipelineBuilder::PipelineBuilder(VkDevice device)

--- a/src/graphics/vulkan/vulkan_pipeline.cpp
+++ b/src/graphics/vulkan/vulkan_pipeline.cpp
@@ -6,8 +6,8 @@ namespace moth_graphics::graphics::vulkan {
     Pipeline::Pipeline(uint32_t hash, VkDevice device, VkPipeline pipeline, std::shared_ptr<Shader> shader)
         : m_hash(hash)
         , m_device(device)
-        , m_pipeline(pipeline, [device](VkPipeline h) { vkDestroyPipeline(device, h, nullptr); })
-        , m_shader(shader) {
+        , m_shader(shader)
+        , m_pipeline(pipeline, [device](VkPipeline h) { vkDestroyPipeline(device, h, nullptr); }) {
     }
 
     PipelineBuilder::PipelineBuilder(VkDevice device)

--- a/src/graphics/vulkan/vulkan_pipeline.h
+++ b/src/graphics/vulkan/vulkan_pipeline.h
@@ -2,6 +2,7 @@
 
 #include "vulkan_shader.h"
 #include "vulkan_renderpass.h"
+#include "vulkan_unique.h"
 
 #include <vulkan/vulkan_core.h>
 
@@ -13,11 +14,11 @@ namespace moth_graphics::graphics::vulkan {
     class Pipeline {
     public:
         Pipeline(uint32_t hash, VkDevice device, VkPipeline pipeline, std::shared_ptr<Shader> shader);
-        ~Pipeline();
+        ~Pipeline() = default;
 
         uint32_t m_hash;
         VkDevice m_device;
-        VkPipeline m_pipeline;
+        UniqueHandle<VkPipeline> m_pipeline;
         std::shared_ptr<Shader> m_shader; // need to keep this around as long as the pipeline uses them
 
     private:

--- a/src/graphics/vulkan/vulkan_pipeline.h
+++ b/src/graphics/vulkan/vulkan_pipeline.h
@@ -18,8 +18,11 @@ namespace moth_graphics::graphics::vulkan {
 
         uint32_t m_hash;
         VkDevice m_device;
-        UniqueHandle<VkPipeline> m_pipeline;
+        // m_shader is declared before m_pipeline so it is destroyed last —
+        // VkPipeline must be destroyed before any VkPipelineLayout owned by
+        // the shader could be released (matches pre-refactor body ordering).
         std::shared_ptr<Shader> m_shader; // need to keep this around as long as the pipeline uses them
+        UniqueHandle<VkPipeline> m_pipeline;
 
     private:
         Pipeline(Pipeline const&) = delete;

--- a/src/graphics/vulkan/vulkan_renderpass.cpp
+++ b/src/graphics/vulkan/vulkan_renderpass.cpp
@@ -6,11 +6,7 @@ namespace moth_graphics::graphics::vulkan {
     RenderPass::RenderPass(uint32_t hash, VkDevice device, VkRenderPass renderPass)
         : m_hash(hash)
         , m_device(device)
-        , m_renderPass(renderPass) {
-    }
-
-    RenderPass ::~RenderPass() {
-        vkDestroyRenderPass(m_device, m_renderPass, nullptr);
+        , m_renderPass(renderPass, [device](VkRenderPass h) { vkDestroyRenderPass(device, h, nullptr); }) {
     }
 
     RenderPassBuilder::RenderPassBuilder(VkDevice device)

--- a/src/graphics/vulkan/vulkan_renderpass.h
+++ b/src/graphics/vulkan/vulkan_renderpass.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "vulkan_unique.h"
+
 #include <vulkan/vulkan_core.h>
 
 #include <vector>
@@ -10,7 +12,7 @@ namespace moth_graphics::graphics::vulkan {
     class RenderPass {
     public:
         RenderPass(uint32_t hash, VkDevice device, VkRenderPass renderPass);
-        ~RenderPass();
+        ~RenderPass() = default;
 
         uint32_t GetHash() const { return m_hash; }
         VkDevice GetDevice() const { return m_device; }
@@ -19,7 +21,7 @@ namespace moth_graphics::graphics::vulkan {
     private:
         uint32_t m_hash;
         VkDevice m_device;
-        VkRenderPass m_renderPass;
+        UniqueHandle<VkRenderPass> m_renderPass;
     };
 
     class RenderPassBuilder {

--- a/src/graphics/vulkan/vulkan_shader.cpp
+++ b/src/graphics/vulkan/vulkan_shader.cpp
@@ -7,25 +7,20 @@ namespace moth_graphics::graphics::vulkan {
     Shader::Shader(uint32_t hash)
         : m_hash(hash)
         , m_device(VK_NULL_HANDLE)
-        , m_descriptorPool(VK_NULL_HANDLE)
-        , m_descriptorSetLayout(VK_NULL_HANDLE)
-        , m_pipelineLayout(VK_NULL_HANDLE) {
+        , m_descriptorPool(VK_NULL_HANDLE) {
     }
 
     Shader::~Shader() {
+        // Descriptor sets must be freed before the pool/layouts they reference.
+        // Member RAII handles the rest in reverse declaration order.
         if (!m_descriptorSets.empty()) {
             std::vector<VkDescriptorSet> freedSets;
+            freedSets.reserve(m_descriptorSets.size());
             for (auto& [key, descriptorSet] : m_descriptorSets) {
                 freedSets.push_back(descriptorSet);
             }
             vkFreeDescriptorSets(m_device, m_descriptorPool, static_cast<uint32_t>(freedSets.size()), freedSets.data());
         }
-
-        for (auto& stage : m_stages) {
-            vkDestroyShaderModule(m_device, stage.m_module, nullptr);
-        }
-        vkDestroyPipelineLayout(m_device, m_pipelineLayout, nullptr);
-        vkDestroyDescriptorSetLayout(m_device, m_descriptorSetLayout, nullptr);
     }
 
     VkDescriptorSet Shader::GetDescriptorSet(Texture& image) {
@@ -41,11 +36,12 @@ namespace moth_graphics::graphics::vulkan {
     VkDescriptorSet Shader::CreateDescriptorSet(Texture& image) {
         VkDescriptorSet descriptorSet = VK_NULL_HANDLE;
 
+        VkDescriptorSetLayout const setLayoutHandle = m_descriptorSetLayout.Get();
         VkDescriptorSetAllocateInfo alloc_info{};
         alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
         alloc_info.descriptorPool = m_descriptorPool;
         alloc_info.descriptorSetCount = 1;
-        alloc_info.pSetLayouts = &m_descriptorSetLayout;
+        alloc_info.pSetLayouts = &setLayoutHandle;
         CHECK_VK_RESULT(vkAllocateDescriptorSets(m_device, &alloc_info, &descriptorSet));
 
         VkSampler const sampler = image.GetVkSampler();
@@ -108,6 +104,7 @@ namespace moth_graphics::graphics::vulkan {
         newShader->m_device = m_device;
         newShader->m_descriptorPool = m_descriptorPool;
         newShader->m_stages.reserve(m_stages.size());
+        VkDevice const device = m_device;
         for (auto& stage : m_stages) {
             Shader::Stage newStage;
             newStage.m_stageFlags = stage.m_stageFlags;
@@ -117,24 +114,37 @@ namespace moth_graphics::graphics::vulkan {
             createInfo.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
             createInfo.codeSize = stage.m_byteCode.size();
             createInfo.pCode = reinterpret_cast<uint32_t const*>(stage.m_byteCode.data()); // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
-            CHECK_VK_RESULT(vkCreateShaderModule(m_device, &createInfo, nullptr, &newStage.m_module));
+            VkShaderModule module = VK_NULL_HANDLE;
+            CHECK_VK_RESULT(vkCreateShaderModule(m_device, &createInfo, nullptr, &module));
+            newStage.m_module = UniqueHandle<VkShaderModule>(module, [device](VkShaderModule h) {
+                vkDestroyShaderModule(device, h, nullptr);
+            });
 
-            newShader->m_stages.push_back(newStage);
+            newShader->m_stages.push_back(std::move(newStage));
         }
 
         VkDescriptorSetLayoutCreateInfo setLayoutInfo{};
         setLayoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
         setLayoutInfo.bindingCount = static_cast<uint32_t>(m_layoutBindings.size());
         setLayoutInfo.pBindings = m_layoutBindings.data();
-        CHECK_VK_RESULT(vkCreateDescriptorSetLayout(m_device, &setLayoutInfo, nullptr, &newShader->m_descriptorSetLayout));
+        VkDescriptorSetLayout setLayout = VK_NULL_HANDLE;
+        CHECK_VK_RESULT(vkCreateDescriptorSetLayout(m_device, &setLayoutInfo, nullptr, &setLayout));
+        newShader->m_descriptorSetLayout = UniqueHandle<VkDescriptorSetLayout>(setLayout, [device](VkDescriptorSetLayout h) {
+            vkDestroyDescriptorSetLayout(device, h, nullptr);
+        });
 
+        VkDescriptorSetLayout const setLayoutHandle = newShader->m_descriptorSetLayout.Get();
         VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
         pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
         pipelineLayoutInfo.setLayoutCount = 1;
-        pipelineLayoutInfo.pSetLayouts = &newShader->m_descriptorSetLayout;
+        pipelineLayoutInfo.pSetLayouts = &setLayoutHandle;
         pipelineLayoutInfo.pushConstantRangeCount = static_cast<uint32_t>(m_pushConstants.size());
         pipelineLayoutInfo.pPushConstantRanges = m_pushConstants.data();
-        CHECK_VK_RESULT(vkCreatePipelineLayout(m_device, &pipelineLayoutInfo, nullptr, &newShader->m_pipelineLayout));
+        VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
+        CHECK_VK_RESULT(vkCreatePipelineLayout(m_device, &pipelineLayoutInfo, nullptr, &pipelineLayout));
+        newShader->m_pipelineLayout = UniqueHandle<VkPipelineLayout>(pipelineLayout, [device](VkPipelineLayout h) {
+            vkDestroyPipelineLayout(device, h, nullptr);
+        });
 
         return newShader;
     }

--- a/src/graphics/vulkan/vulkan_shader.h
+++ b/src/graphics/vulkan/vulkan_shader.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "vulkan_unique.h"
+
 #include <vulkan/vulkan_core.h>
 
 #include <memory>
@@ -18,7 +20,7 @@ namespace moth_graphics::graphics::vulkan {
 
         struct Stage {
             VkShaderStageFlagBits m_stageFlags;
-            VkShaderModule m_module;
+            UniqueHandle<VkShaderModule> m_module;
             std::string m_entryPoint;
         };
 
@@ -26,14 +28,15 @@ namespace moth_graphics::graphics::vulkan {
         VkDevice m_device;
         VkDescriptorPool m_descriptorPool;
         std::vector<Shader::Stage> m_stages;
-        VkDescriptorSetLayout m_descriptorSetLayout;
-        VkPipelineLayout m_pipelineLayout;
+        UniqueHandle<VkDescriptorSetLayout> m_descriptorSetLayout;
+        UniqueHandle<VkPipelineLayout> m_pipelineLayout;
 
         VkDescriptorSet GetDescriptorSet(Texture& image);
         VkDescriptorSet CreateDescriptorSet(Texture& image);
 
         // Keyed by (image_id, sampler) so that the same texture with two different
         // filter modes can coexist without any descriptor set being freed mid-frame.
+        // Sets are batch-freed in the destructor before the pool/layouts go away.
         std::map<std::pair<uint32_t, VkSampler>, VkDescriptorSet> m_descriptorSets;
     };
 

--- a/src/graphics/vulkan/vulkan_swapchain.cpp
+++ b/src/graphics/vulkan/vulkan_swapchain.cpp
@@ -25,8 +25,7 @@ namespace {
 namespace moth_graphics::graphics::vulkan {
     Swapchain::Swapchain(SurfaceContext& context, RenderPass& renderPass, VkSurfaceKHR surface, VkExtent2D extent)
         : m_context(context)
-        , m_extent{}
-        , m_vkSwapchain(VK_NULL_HANDLE) {
+        , m_extent{} {
         VkSurfaceCapabilitiesKHR capabilities;
         vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_context.GetVkPhysicalDevice(), surface, &capabilities);
         m_extent = chooseSwapExtent(extent.width, extent.height, capabilities);
@@ -54,7 +53,12 @@ namespace moth_graphics::graphics::vulkan {
         createInfo.presentMode = presentMode;
         createInfo.clipped = VK_TRUE;
         createInfo.oldSwapchain = VK_NULL_HANDLE;
-        CHECK_VK_RESULT(vkCreateSwapchainKHR(m_context.GetVkDevice(), &createInfo, nullptr, &m_vkSwapchain));
+        VkSwapchainKHR swapchain = VK_NULL_HANDLE;
+        CHECK_VK_RESULT(vkCreateSwapchainKHR(m_context.GetVkDevice(), &createInfo, nullptr, &swapchain));
+        VkDevice const device = m_context.GetVkDevice();
+        m_vkSwapchain = UniqueHandle<VkSwapchainKHR>(swapchain, [device](VkSwapchainKHR h) {
+            vkDestroySwapchainKHR(device, h, nullptr);
+        });
 
         uint32_t imageCount = 0;
         std::vector<VkImage> swapchainImages;
@@ -87,8 +91,16 @@ namespace moth_graphics::graphics::vulkan {
             auto slot = std::make_shared<FrameSlot>();
             VkSemaphoreCreateInfo semaphoreInfo{};
             semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-            CHECK_VK_RESULT(vkCreateSemaphore(m_context.GetVkDevice(), &semaphoreInfo, nullptr, &slot->imageAvailable));
-            CHECK_VK_RESULT(vkCreateSemaphore(m_context.GetVkDevice(), &semaphoreInfo, nullptr, &slot->renderFinished));
+            VkSemaphore imageAvailable = VK_NULL_HANDLE;
+            VkSemaphore renderFinished = VK_NULL_HANDLE;
+            CHECK_VK_RESULT(vkCreateSemaphore(m_context.GetVkDevice(), &semaphoreInfo, nullptr, &imageAvailable));
+            CHECK_VK_RESULT(vkCreateSemaphore(m_context.GetVkDevice(), &semaphoreInfo, nullptr, &renderFinished));
+            slot->imageAvailable = UniqueHandle<VkSemaphore>(imageAvailable, [device](VkSemaphore h) {
+                vkDestroySemaphore(device, h, nullptr);
+            });
+            slot->renderFinished = UniqueHandle<VkSemaphore>(renderFinished, [device](VkSemaphore h) {
+                vkDestroySemaphore(device, h, nullptr);
+            });
             m_frames.push_back(slot);
         }
         commandBuffer->SubmitAndWait();
@@ -100,19 +112,6 @@ namespace moth_graphics::graphics::vulkan {
         for (auto& framebuffer : m_framebuffers) {
             framebuffer->GetCommandBuffer().Reset();
         }
-    }
-
-    Swapchain::~Swapchain() {
-        for (uint32_t i = 0; i < m_imageCount; ++i) {
-            auto& slot = m_frames[i];
-            if (slot->imageAvailable != VK_NULL_HANDLE) {
-                vkDestroySemaphore(m_context.GetVkDevice(), slot->imageAvailable, nullptr);
-            }
-            if (slot->renderFinished != VK_NULL_HANDLE) {
-                vkDestroySemaphore(m_context.GetVkDevice(), slot->renderFinished, nullptr);
-            }
-        }
-        vkDestroySwapchainKHR(m_context.GetVkDevice(), m_vkSwapchain, nullptr);
     }
 
     Framebuffer* Swapchain::GetNextFramebuffer() {

--- a/src/graphics/vulkan/vulkan_swapchain.h
+++ b/src/graphics/vulkan/vulkan_swapchain.h
@@ -3,6 +3,7 @@
 #include "moth_graphics/graphics/vulkan/vulkan_surface_context.h"
 #include "vulkan_framebuffer.h"
 #include "vulkan_renderpass.h"
+#include "vulkan_unique.h"
 
 #include <vulkan/vulkan_core.h>
 
@@ -12,15 +13,15 @@
 
 namespace moth_graphics::graphics::vulkan {
     struct FrameSlot {
-        VkSemaphore imageAvailable;
-        VkSemaphore renderFinished;
+        UniqueHandle<VkSemaphore> imageAvailable;
+        UniqueHandle<VkSemaphore> renderFinished;
         uint32_t lastImageIndex = UINT32_MAX;
     };
 
     class Swapchain {
     public:
         Swapchain(SurfaceContext& context, RenderPass& renderPass, VkSurfaceKHR surface, VkExtent2D extent);
-        ~Swapchain();
+        ~Swapchain() = default;
 
         VkExtent2D GetExtent() const { return m_extent; }
 
@@ -39,7 +40,10 @@ namespace moth_graphics::graphics::vulkan {
     private:
         SurfaceContext& m_context;
         VkExtent2D m_extent;
-        VkSwapchainKHR m_vkSwapchain;
+        // Framebuffers reference the swapchain's images, so they must be torn
+        // down before the swapchain handle. Declaration order: swapchain first
+        // (destroyed last), framebuffers after (destroyed first).
+        UniqueHandle<VkSwapchainKHR> m_vkSwapchain;
         std::vector<std::unique_ptr<Framebuffer>> m_framebuffers;
         uint32_t m_currentFrame = 0;
         uint32_t m_imageCount = 0;

--- a/src/graphics/vulkan/vulkan_texture.cpp
+++ b/src/graphics/vulkan/vulkan_texture.cpp
@@ -60,8 +60,13 @@ namespace moth_graphics::graphics::vulkan {
         , m_vkExtent(extent)
         , m_vkFormat(format)
         , m_vkImage(image)
-        , m_vkView(view)
         , m_owningImage(owning) {
+        if (view != VK_NULL_HANDLE) {
+            VkDevice const device = m_context.GetVkDevice();
+            m_vkView = UniqueHandle<VkImageView>(view, [device](VkImageView h) {
+                vkDestroyImageView(device, h, nullptr);
+            });
+        }
         Texture::SetFilter(TextureFilter::Linear, TextureFilter::Linear);
     }
 
@@ -78,18 +83,9 @@ namespace moth_graphics::graphics::vulkan {
     }
 
     Texture::~Texture() {
-        if (m_vkDescriptorSet != VK_NULL_HANDLE) {
-            ImGui_ImplVulkan_RemoveTexture(m_vkDescriptorSet);
-        }
-        if (m_vkSamplerLinear != VK_NULL_HANDLE) {
-            vkDestroySampler(m_context.GetVkDevice(), m_vkSamplerLinear, nullptr);
-        }
-        if (m_vkSamplerNearest != VK_NULL_HANDLE) {
-            vkDestroySampler(m_context.GetVkDevice(), m_vkSamplerNearest, nullptr);
-        }
-        if (m_vkView != VK_NULL_HANDLE) {
-            vkDestroyImageView(m_context.GetVkDevice(), m_vkView, nullptr);
-        }
+        // Sampler / view / descriptor set members release themselves via RAII.
+        // Image + VMA allocation are paired and gated by m_owningImage, so they
+        // remain manually managed here.
         if (m_owningImage && m_vkImage != VK_NULL_HANDLE) {
             vmaFreeMemory(m_context.GetVmaAllocator(), m_vmaAllocation);
             vkDestroyImage(m_context.GetVkDevice(), m_vkImage, nullptr);
@@ -97,29 +93,33 @@ namespace moth_graphics::graphics::vulkan {
     }
 
     VkImageView Texture::GetVkView() const {
-        if (m_vkView == VK_NULL_HANDLE) {
+        if (!m_vkView) {
             CreateView();
         }
         return m_vkView;
     }
     VkSampler Texture::GetVkSampler() const {
         bool const nearest = (m_minFilter == VK_FILTER_NEAREST || m_magFilter == VK_FILTER_NEAREST);
-        VkSampler& slot = nearest ? m_vkSamplerNearest : m_vkSamplerLinear;
-        if (slot == VK_NULL_HANDLE) {
-            slot = CreateSampler(m_minFilter, m_magFilter);
+        UniqueHandle<VkSampler>& slot = nearest ? m_vkSamplerNearest : m_vkSamplerLinear;
+        if (!slot) {
+            VkDevice const device = m_context.GetVkDevice();
+            slot = UniqueHandle<VkSampler>(CreateSampler(m_minFilter, m_magFilter), [device](VkSampler h) {
+                vkDestroySampler(device, h, nullptr);
+            });
         }
         return slot;
     }
 
     VkDescriptorSet Texture::GetDescriptorSet() const {
         VkSampler const currentSampler = GetVkSampler();
-        if (m_vkDescriptorSet != VK_NULL_HANDLE && m_vkDescriptorSetSampler == currentSampler) {
+        if (m_vkDescriptorSet && m_vkDescriptorSetSampler == currentSampler) {
             return m_vkDescriptorSet;
         }
-        if (m_vkDescriptorSet != VK_NULL_HANDLE) {
-            ImGui_ImplVulkan_RemoveTexture(m_vkDescriptorSet);
-        }
-        m_vkDescriptorSet = ImGui_ImplVulkan_AddTexture(currentSampler, GetVkView(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        m_vkDescriptorSet.Reset();
+        VkDescriptorSet const newSet = ImGui_ImplVulkan_AddTexture(currentSampler, GetVkView(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        m_vkDescriptorSet = UniqueHandle<VkDescriptorSet>(newSet, [](VkDescriptorSet h) {
+            ImGui_ImplVulkan_RemoveTexture(h);
+        });
         m_vkDescriptorSetSampler = currentSampler;
         return m_vkDescriptorSet;
     }
@@ -170,7 +170,12 @@ namespace moth_graphics::graphics::vulkan {
         info.subresourceRange.baseArrayLayer = 0;
         info.subresourceRange.layerCount = 1;
         info.image = m_vkImage;
-        CHECK_VK_RESULT(vkCreateImageView(m_context.GetVkDevice(), &info, nullptr, &m_vkView));
+        VkImageView view = VK_NULL_HANDLE;
+        CHECK_VK_RESULT(vkCreateImageView(m_context.GetVkDevice(), &info, nullptr, &view));
+        VkDevice const device = m_context.GetVkDevice();
+        m_vkView = UniqueHandle<VkImageView>(view, [device](VkImageView h) {
+            vkDestroyImageView(device, h, nullptr);
+        });
     }
 
     namespace {
@@ -282,20 +287,13 @@ namespace moth_graphics::graphics::vulkan {
         // Address mode affects sampler state. Invalidate cached samplers so they
         // are recreated with the new mode on next use. Safe to destroy here because
         // SetAddressMode is not called during frame recording.
-        if (m_vkSamplerLinear != VK_NULL_HANDLE) {
+        if (m_vkSamplerLinear) {
             vkDeviceWaitIdle(m_context.GetVkDevice());
-            vkDestroySampler(m_context.GetVkDevice(), m_vkSamplerLinear, nullptr);
-            m_vkSamplerLinear = VK_NULL_HANDLE;
         }
-        if (m_vkSamplerNearest != VK_NULL_HANDLE) {
-            vkDestroySampler(m_context.GetVkDevice(), m_vkSamplerNearest, nullptr);
-            m_vkSamplerNearest = VK_NULL_HANDLE;
-        }
-        if (m_vkDescriptorSet != VK_NULL_HANDLE) {
-            ImGui_ImplVulkan_RemoveTexture(m_vkDescriptorSet);
-            m_vkDescriptorSet = VK_NULL_HANDLE;
-            m_vkDescriptorSetSampler = VK_NULL_HANDLE;
-        }
+        m_vkSamplerLinear.Reset();
+        m_vkSamplerNearest.Reset();
+        m_vkDescriptorSet.Reset();
+        m_vkDescriptorSetSampler = VK_NULL_HANDLE;
     }
 
     VkSampler Texture::CreateSampler(VkFilter min, VkFilter mag) const {

--- a/src/graphics/vulkan/vulkan_texture.cpp
+++ b/src/graphics/vulkan/vulkan_texture.cpp
@@ -83,9 +83,14 @@ namespace moth_graphics::graphics::vulkan {
     }
 
     Texture::~Texture() {
-        // Sampler / view / descriptor set members release themselves via RAII.
-        // Image + VMA allocation are paired and gated by m_owningImage, so they
-        // remain manually managed here.
+        // Release dependents (descriptor set, samplers, view) before the image
+        // they reference. Member RAII would also do this in reverse declaration
+        // order, but the image+VMA pair is freed manually below and would
+        // otherwise run before the wrapped members.
+        m_vkDescriptorSet.Reset();
+        m_vkSamplerNearest.Reset();
+        m_vkSamplerLinear.Reset();
+        m_vkView.Reset();
         if (m_owningImage && m_vkImage != VK_NULL_HANDLE) {
             vmaFreeMemory(m_context.GetVmaAllocator(), m_vmaAllocation);
             vkDestroyImage(m_context.GetVkDevice(), m_vkImage, nullptr);
@@ -285,9 +290,10 @@ namespace moth_graphics::graphics::vulkan {
         m_addressModeU = newU;
         m_addressModeV = newV;
         // Address mode affects sampler state. Invalidate cached samplers so they
-        // are recreated with the new mode on next use. Safe to destroy here because
-        // SetAddressMode is not called during frame recording.
-        if (m_vkSamplerLinear) {
+        // are recreated with the new mode on next use. Wait for any in-flight
+        // command buffer that may still reference either sampler/descriptor set
+        // before destroying them.
+        if (m_vkSamplerLinear || m_vkSamplerNearest) {
             vkDeviceWaitIdle(m_context.GetVkDevice());
         }
         m_vkSamplerLinear.Reset();

--- a/src/graphics/vulkan/vulkan_texture.h
+++ b/src/graphics/vulkan/vulkan_texture.h
@@ -2,6 +2,7 @@
 
 #include "moth_graphics/graphics/itexture.h"
 #include "moth_graphics/graphics/vulkan/vulkan_surface_context.h"
+#include "vulkan_unique.h"
 
 #include <vulkan/vulkan_core.h>
 
@@ -47,16 +48,19 @@ namespace moth_graphics::graphics::vulkan {
         VkExtent2D m_vkExtent;
         VkFormat m_vkFormat;
 
+        // Image+VMA allocation are paired and freed together in the destructor;
+        // they stay raw because vmaFreeMemory + vkDestroyImage operate as a unit
+        // gated by m_owningImage.
         VkImage m_vkImage = VK_NULL_HANDLE;
         VmaAllocation m_vmaAllocation = VK_NULL_HANDLE;
-        mutable VkImageView m_vkView = VK_NULL_HANDLE;
+        mutable UniqueHandle<VkImageView> m_vkView;
         // One persistent sampler per filter mode, lazily created. Never destroyed
         // during a frame — only in the destructor — so command buffers in flight are
         // never invalidated by a mid-frame SetFilter call.
-        mutable VkSampler m_vkSamplerLinear = VK_NULL_HANDLE;
-        mutable VkSampler m_vkSamplerNearest = VK_NULL_HANDLE;
+        mutable UniqueHandle<VkSampler> m_vkSamplerLinear;
+        mutable UniqueHandle<VkSampler> m_vkSamplerNearest;
         // ImGui-managed descriptor set and the sampler it was created with.
-        mutable VkDescriptorSet m_vkDescriptorSet = VK_NULL_HANDLE;
+        mutable UniqueHandle<VkDescriptorSet> m_vkDescriptorSet;
         mutable VkSampler m_vkDescriptorSetSampler = VK_NULL_HANDLE;
         VkFilter m_minFilter = VK_FILTER_LINEAR;
         VkFilter m_magFilter = VK_FILTER_LINEAR;

--- a/src/graphics/vulkan/vulkan_unique.h
+++ b/src/graphics/vulkan/vulkan_unique.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <vulkan/vulkan_core.h>
+
+#include <functional>
+#include <utility>
+
+namespace moth_graphics::graphics::vulkan {
+    /// Move-only RAII wrapper for a Vulkan-style handle. The deleter is type-erased
+    /// so any of the destroy/free/Vma* functions can be supplied at construction
+    /// (typically as a small lambda capturing the device or allocator).
+    ///
+    /// The wrapped handle is stored as type Handle{} when empty, which maps to
+    /// VK_NULL_HANDLE for non-dispatchable handles and nullptr for pointer-typed
+    /// handles such as VmaAllocation/VmaAllocator.
+    template <typename Handle>
+    class UniqueHandle {
+    public:
+        using Deleter = std::function<void(Handle)>;
+
+        UniqueHandle() = default;
+        UniqueHandle(Handle handle, Deleter deleter)
+            : m_handle(handle)
+            , m_deleter(std::move(deleter)) {
+        }
+
+        ~UniqueHandle() { Reset(); }
+
+        UniqueHandle(UniqueHandle const&) = delete;
+        UniqueHandle& operator=(UniqueHandle const&) = delete;
+
+        UniqueHandle(UniqueHandle&& other) noexcept
+            : m_handle(other.m_handle)
+            , m_deleter(std::move(other.m_deleter)) {
+            other.m_handle = Handle{};
+        }
+
+        UniqueHandle& operator=(UniqueHandle&& other) noexcept {
+            if (this != &other) {
+                Reset();
+                m_handle = other.m_handle;
+                m_deleter = std::move(other.m_deleter);
+                other.m_handle = Handle{};
+            }
+            return *this;
+        }
+
+        Handle Get() const { return m_handle; }
+        operator Handle() const { return m_handle; } // NOLINT(google-explicit-constructor)
+        explicit operator bool() const { return m_handle != Handle{}; }
+
+        Handle Release() {
+            Handle h = m_handle;
+            m_handle = Handle{};
+            return h;
+        }
+
+        void Reset() {
+            if (m_handle != Handle{} && m_deleter) {
+                m_deleter(m_handle);
+            }
+            m_handle = Handle{};
+        }
+
+    private:
+        Handle m_handle{};
+        Deleter m_deleter;
+    };
+}


### PR DESCRIPTION
## Summary
- Adds `UniqueHandle<T>` (move-only, type-erased deleter) in `src/graphics/vulkan/vulkan_unique.h`
- Applies it to internal Vulkan classes that own multiple handles or had manual destructors: Fence, RenderPass, Pipeline, Framebuffer, Swapchain (+ FrameSlot semaphores), Shader (modules / set layout / pipeline layout), Texture (image view, samplers, ImGui descriptor set), Graphics (pipeline cache)
- No public-API or behavioural changes; getters keep returning the underlying handle via implicit conversion

## Intentionally not wrapped
- **Buffer**, **Texture image+VMA** — `VkBuffer`/`VkImage` are freed jointly with `VmaAllocation` via `vmaDestroyBuffer`/paired calls; wrapping just the handle would require a `this`-capturing deleter that doesn't survive moves
- **CommandBuffer** — single handle, one-line dtor
- **Public-header classes** — `SurfaceContext`, `glfw::Window`, `sdl::Window`: the API constraint asked for internal-only changes
- **Debug messenger** — uses `vkGetInstanceProcAddr` dynamic lookup; doesn't fit the wrapper

## Caller-side adjustments
- `pSetLayouts = &m_descriptorSetLayout` now reads through `.Get()` into a local first (a pointer to `UniqueHandle` is not a pointer to the handle). Three sites: `Shader::CreateDescriptorSet`, `ShaderBuilder::Build`, `Font::GetVKDescriptorSetForShader`.
- `Framebuffer::GetAvailableSemaphore`/`GetRenderFinishedSemaphore` use `.Get()` so the ternary branches share a type.
- `Shader::Stage` is now move-only; `m_stages.push_back(stage)` became `push_back(std::move(stage))`.

## Test plan
- [ ] Build moth_graphics Debug on Linux (`conan install` + `conan-debug` preset) and run tests
- [ ] Build moth_graphics Release on Linux and Windows via CI
- [ ] Smoke-test downstream consumers (moth_editor, TinCan) start, render a frame, and exit cleanly — exercises Texture/Shader/Swapchain/Framebuffer destruction paths
- [ ] Verify Vulkan validation layer is silent (no new validation messages from changed destruction order)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved graphics engine stability and reliability through enhanced automatic resource management for Vulkan rendering resources, reducing potential memory leaks and strengthening overall system robustness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/instinkt900/moth_graphics/pull/51)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->