### PR TITLE
fix: letterbox consistently across SDL and Vulkan backends

### DIFF
--- a/src/graphics/sdl/sdl_graphics.cpp
+++ b/src/graphics/sdl/sdl_graphics.cpp
@@ -16,6 +16,12 @@ namespace moth_graphics::graphics::sdl {
     Graphics::~Graphics() = default;
 
     void Graphics::Begin() {
+        // Clear the full physical window with black before any logical-size
+        // letterboxing kicks in. With a logical size set, SDL_RenderClear only
+        // clears the logical viewport, leaving the letterbox bars uninitialised.
+        SDL_RenderSetLogicalSize(m_surfaceContext.GetRenderer(), 0, 0);
+        SDL_SetRenderDrawColor(m_surfaceContext.GetRenderer(), 0, 0, 0, 255);
+        SDL_RenderClear(m_surfaceContext.GetRenderer());
     }
 
     void Graphics::End() {

--- a/src/graphics/sdl/sdl_graphics.cpp
+++ b/src/graphics/sdl/sdl_graphics.cpp
@@ -22,6 +22,10 @@ namespace moth_graphics::graphics::sdl {
         SDL_RenderSetLogicalSize(m_surfaceContext.GetRenderer(), 0, 0);
         SDL_SetRenderDrawColor(m_surfaceContext.GetRenderer(), 0, 0, 0, 255);
         SDL_RenderClear(m_surfaceContext.GetRenderer());
+        // Restore the renderer's draw color so subsequent primitive draws
+        // honour the cached m_drawColor instead of inheriting black.
+        ColorComponents const components(m_drawColor);
+        SDL_SetRenderDrawColor(m_surfaceContext.GetRenderer(), components.r, components.g, components.b, components.a);
     }
 
     void Graphics::End() {

--- a/src/graphics/vulkan/vulkan_graphics.cpp
+++ b/src/graphics/vulkan/vulkan_graphics.cpp
@@ -479,6 +479,14 @@ namespace moth_graphics::graphics::vulkan {
         if (context == nullptr) {
             return;
         }
+        if (logicalSize.x <= 0 || logicalSize.y <= 0) {
+            return;
+        }
+
+        // Flush any queued geometry under the previous viewport/scissor state
+        // before mutating it, so existing batches still render with the
+        // settings they were authored against.
+        FlushPendingBatch();
 
         // Letterbox: fit the logical aspect inside the physical extent and
         // centre it. Bars outside the viewport stay black via the render pass

--- a/src/graphics/vulkan/vulkan_graphics.cpp
+++ b/src/graphics/vulkan/vulkan_graphics.cpp
@@ -479,7 +479,42 @@ namespace moth_graphics::graphics::vulkan {
         if (context == nullptr) {
             return;
         }
+
+        // Letterbox: fit the logical aspect inside the physical extent and
+        // centre it. Bars outside the viewport stay black via the render pass
+        // clear.
+        VkExtent2D const physical = context->m_target->GetVkExtent();
+        float const logicalAspect = static_cast<float>(logicalSize.x) / static_cast<float>(logicalSize.y);
+        float const physicalAspect = static_cast<float>(physical.width) / static_cast<float>(physical.height);
+
+        float fitWidth = static_cast<float>(physical.width);
+        float fitHeight = static_cast<float>(physical.height);
+        if (physicalAspect > logicalAspect) {
+            fitWidth = fitHeight * logicalAspect;
+        } else {
+            fitHeight = fitWidth / logicalAspect;
+        }
+        float const offsetX = (static_cast<float>(physical.width) - fitWidth) * 0.5f;
+        float const offsetY = (static_cast<float>(physical.height) - fitHeight) * 0.5f;
+
         auto& commandBuffer = context->m_target->GetCommandBuffer();
+
+        VkViewport viewport;
+        viewport.x = offsetX;
+        viewport.y = offsetY;
+        viewport.width = fitWidth;
+        viewport.height = fitHeight;
+        viewport.minDepth = 0.0f;
+        viewport.maxDepth = 1.0f;
+        commandBuffer.SetViewport(viewport);
+
+        VkRect2D scissor;
+        scissor.offset.x = static_cast<int32_t>(offsetX);
+        scissor.offset.y = static_cast<int32_t>(offsetY);
+        scissor.extent.width = static_cast<uint32_t>(fitWidth);
+        scissor.extent.height = static_cast<uint32_t>(fitHeight);
+        commandBuffer.SetScissor(scissor);
+
         PushConstants constants;
         constants.xyScale = { 2.0f / static_cast<float>(logicalSize.x), 2.0f / static_cast<float>(logicalSize.y) };
         constants.xyOffset = { -1.0f, -1.0f };


### PR DESCRIPTION
## Summary
- SDL `Graphics::Begin` now clears the full physical window with black before letterboxing kicks in, so the bars created by `SDL_RenderSetLogicalSize` no longer accumulate uninitialised back-buffer contents.
- Vulkan `SetLogicalSize` now computes the centred fit rect for the logical aspect inside the physical extent and sets `vkCmdSetViewport` + scissor accordingly. The render-pass clear handles the bars.

Both backends now letterbox identically when a layer opts into `UseRenderSize()` and the window aspect differs from the logical aspect.

## Background
When a layer reports `UseRenderSize() == true`, `LayerStack::Draw` calls `IGraphics::SetLogicalSize` with the layer's render size before each draw, so the same logical coordinate system maps onto windows of different sizes. The two backends interpreted this differently:

- SDL relied on `SDL_RenderSetLogicalSize` to do the scaling, which automatically letterboxes — but the bars stayed uncleared because `SDL_RenderClear` with logical size active only clears the logical viewport.
- Vulkan only updated the vertex shader's push-constant scale, which stretches logical coords across the full surface without preserving aspect.

## Test plan
- [ ] Build SDL backend with a consumer that opts into `UseRenderSize()`; window at non-matching aspect (e.g. maximised with a title bar) should show clean black bars on left/right, no garbage.
- [ ] Build Vulkan backend with the same consumer; rendering should letterbox identically to SDL — no stretching, black bars where the logical aspect doesn't fit.
- [ ] Match window aspect to logical aspect; both backends should fill the window edge-to-edge with no visible bars.
- [ ] Resize the window at runtime; both backends should re-letterbox correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented black/flash artifacts during renderer startup and fullscreen transitions.
  * Improved aspect-ratio preservation and letterboxing so content scales and centers correctly.
  * Handled invalid or zero logical sizes gracefully to avoid rendering glitches during size changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/instinkt900/moth_graphics/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->