### PR TITLE
feat: add ITexture::UpdatePixels for sub-rect texture writes

### DIFF
--- a/include/moth_graphics/graphics/itexture.h
+++ b/include/moth_graphics/graphics/itexture.h
@@ -45,5 +45,17 @@ namespace moth_graphics::graphics {
         ///        image dimensions; @c sourceRect.topLeft is the offset within
         ///        the texture to start reading from.
         virtual void SaveToPNG(std::filesystem::path const& path, IntRect const& sourceRect) = 0;
+
+        /// @brief Replace a sub-region of the texture with new RGBA pixel data.
+        ///
+        /// Only supported on textures created via
+        /// @c AssetContext::TextureFromPixels (i.e. CPU-writable textures).
+        /// @c pixels must point to a tightly packed RGBA buffer of size
+        /// @c destRect.w() * destRect.h() * 4 bytes, with row pitch equal to
+        /// @c destRect.w() * 4. The destination rect must lie fully within the
+        /// texture's bounds.
+        /// @param destRect Region of the texture to overwrite.
+        /// @param pixels   Source pixel data, RGBA8 tightly packed.
+        virtual void UpdatePixels(IntRect const& destRect, uint8_t const* pixels) = 0;
     };
 }

--- a/include/moth_graphics/graphics/itexture.h
+++ b/include/moth_graphics/graphics/itexture.h
@@ -5,6 +5,7 @@
 #include "moth_graphics/utils/rect.h"
 #include "moth_graphics/utils/vector.h"
 
+#include <cstdint>
 #include <filesystem>
 
 namespace moth_graphics::graphics {

--- a/src/graphics/sdl/sdl_texture.cpp
+++ b/src/graphics/sdl/sdl_texture.cpp
@@ -67,6 +67,9 @@ namespace moth_graphics::graphics::sdl {
             return;
         }
         SDL_Rect const sdlRect = ToSDL(destRect);
+        if (sdlRect.w <= 0 || sdlRect.h <= 0) {
+            return;
+        }
         int const pitch = sdlRect.w * 4;
         if (SDL_UpdateTexture(m_texture->GetImpl(), &sdlRect, pixels, pitch) != 0) {
             spdlog::error("Texture::UpdatePixels: SDL_UpdateTexture failed: {}", SDL_GetError());

--- a/src/graphics/sdl/sdl_texture.cpp
+++ b/src/graphics/sdl/sdl_texture.cpp
@@ -62,6 +62,17 @@ namespace moth_graphics::graphics::sdl {
         SDL_SetRenderTarget(m_renderer, prevTarget);
     }
 
+    void Texture::UpdatePixels(IntRect const& destRect, uint8_t const* pixels) {
+        if (pixels == nullptr) {
+            return;
+        }
+        SDL_Rect const sdlRect = ToSDL(destRect);
+        int const pitch = sdlRect.w * 4;
+        if (SDL_UpdateTexture(m_texture->GetImpl(), &sdlRect, pixels, pitch) != 0) {
+            spdlog::error("Texture::UpdatePixels: SDL_UpdateTexture failed: {}", SDL_GetError());
+        }
+    }
+
     std::unique_ptr<Texture> Texture::FromFile(SDL_Renderer* renderer, std::filesystem::path const& path) {
         auto surface = CreateSurfaceRef(path);
         if (!surface) {

--- a/src/graphics/sdl/sdl_texture.h
+++ b/src/graphics/sdl/sdl_texture.h
@@ -21,6 +21,7 @@ namespace moth_graphics::graphics::sdl {
         void SetAddressMode(TextureAddressMode u, TextureAddressMode v) override {} // not supported in SDL2
         void DrawImGui(IntVec2 const& size, FloatVec2 const& uv0, FloatVec2 const& uv1) const override;
         void SaveToPNG(std::filesystem::path const& path, IntRect const& sourceRect) override;
+        void UpdatePixels(IntRect const& destRect, uint8_t const* pixels) override;
 
         SDLTextureRef GetSDLTexture() const { return m_texture; }
 

--- a/src/graphics/vulkan/vulkan_texture.cpp
+++ b/src/graphics/vulkan/vulkan_texture.cpp
@@ -281,6 +281,51 @@ namespace moth_graphics::graphics::vulkan {
         stagingImage->Unmap();
     }
 
+    void Texture::UpdatePixels(IntRect const& destRect, uint8_t const* pixels) {
+        if (pixels == nullptr) {
+            return;
+        }
+        auto const regionWidth = static_cast<uint32_t>(destRect.w());
+        auto const regionHeight = static_cast<uint32_t>(destRect.h());
+        if (regionWidth == 0 || regionHeight == 0) {
+            return;
+        }
+
+        VkDeviceSize const regionSize = static_cast<VkDeviceSize>(regionWidth) * regionHeight * 4;
+        auto stagingBuffer = std::make_unique<Buffer>(m_context, regionSize,
+            VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+        void* mapped = stagingBuffer->Map();
+        memcpy(mapped, pixels, static_cast<size_t>(regionSize));
+        stagingBuffer->Unmap();
+
+        // Texture is assumed to be in SHADER_READ_ONLY_OPTIMAL between frames —
+        // that's how FromRGBA leaves it and how sampling expects it. Transition
+        // through TRANSFER_DST_OPTIMAL for the copy, then back.
+        VkImageLayout const srcLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+        auto commandBuffer = std::make_unique<CommandBuffer>(m_context);
+        commandBuffer->BeginRecord();
+        commandBuffer->TransitionImageLayout(*this, m_vkFormat, srcLayout, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+        VkBufferImageCopy region{};
+        region.bufferOffset = 0;
+        region.bufferRowLength = 0;     // tightly packed
+        region.bufferImageHeight = 0;
+        region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        region.imageSubresource.mipLevel = 0;
+        region.imageSubresource.baseArrayLayer = 0;
+        region.imageSubresource.layerCount = 1;
+        region.imageOffset = { static_cast<int32_t>(destRect.topLeft.x), static_cast<int32_t>(destRect.topLeft.y), 0 };
+        region.imageExtent = { regionWidth, regionHeight, 1 };
+        vkCmdCopyBufferToImage(commandBuffer->GetVkCommandBuffer(),
+            stagingBuffer->GetVKBuffer(), m_vkImage,
+            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+        commandBuffer->TransitionImageLayout(*this, m_vkFormat, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, srcLayout);
+        commandBuffer->SubmitAndWait();
+    }
+
     void Texture::SetAddressMode(TextureAddressMode u, TextureAddressMode v) {
         VkSamplerAddressMode const newU = ToVkAddressMode(u);
         VkSamplerAddressMode const newV = ToVkAddressMode(v);

--- a/src/graphics/vulkan/vulkan_texture.cpp
+++ b/src/graphics/vulkan/vulkan_texture.cpp
@@ -285,11 +285,24 @@ namespace moth_graphics::graphics::vulkan {
         if (pixels == nullptr) {
             return;
         }
-        auto const regionWidth = static_cast<uint32_t>(destRect.w());
-        auto const regionHeight = static_cast<uint32_t>(destRect.h());
-        if (regionWidth == 0 || regionHeight == 0) {
+        // Validate signed dimensions before casting — a negative value would
+        // wrap to a huge unsigned and bypass the zero check, leading to a huge
+        // staging allocation. Also bounds-check against the texture extent so
+        // vkCmdCopyBufferToImage never sees an out-of-range region.
+        int const signedW = destRect.w();
+        int const signedH = destRect.h();
+        if (signedW <= 0 || signedH <= 0) {
             return;
         }
+        if (destRect.topLeft.x < 0 || destRect.topLeft.y < 0) {
+            return;
+        }
+        if (static_cast<uint32_t>(destRect.bottomRight.x) > m_vkExtent.width
+         || static_cast<uint32_t>(destRect.bottomRight.y) > m_vkExtent.height) {
+            return;
+        }
+        auto const regionWidth = static_cast<uint32_t>(signedW);
+        auto const regionHeight = static_cast<uint32_t>(signedH);
 
         VkDeviceSize const regionSize = static_cast<VkDeviceSize>(regionWidth) * regionHeight * 4;
         auto stagingBuffer = std::make_unique<Buffer>(m_context, regionSize,

--- a/src/graphics/vulkan/vulkan_texture.h
+++ b/src/graphics/vulkan/vulkan_texture.h
@@ -41,6 +41,7 @@ namespace moth_graphics::graphics::vulkan {
         void SetAddressMode(TextureAddressMode u, TextureAddressMode v) override;
         void DrawImGui(IntVec2 const& size, FloatVec2 const& uv0, FloatVec2 const& uv1) const override;
         void SaveToPNG(std::filesystem::path const& path, IntRect const& sourceRect) override;
+        void UpdatePixels(IntRect const& destRect, uint8_t const* pixels) override;
 
     protected:
         uint32_t m_id;

--- a/tests/src/test_spritesheet.cpp
+++ b/tests/src/test_spritesheet.cpp
@@ -19,6 +19,7 @@ namespace {
         void SetAddressMode(TextureAddressMode, TextureAddressMode) override {}
         void DrawImGui(IntVec2 const&, FloatVec2 const&, FloatVec2 const&) const override {}
         void SaveToPNG(std::filesystem::path const&, IntRect const&) override {}
+        void UpdatePixels(IntRect const&, uint8_t const*) override {}
     };
 
     Image MakeDummyImage() {


### PR DESCRIPTION
## Summary
- Adds `ITexture::UpdatePixels(IntRect destRect, uint8_t const* pixels)` to the moth_graphics texture interface.
- Implemented for both backends:
  - SDL: `SDL_UpdateTexture` against the existing streaming texture.
  - Vulkan: stage to a host-visible buffer, transition `SHADER_READ_ONLY_OPTIMAL` → `TRANSFER_DST_OPTIMAL`, `vkCmdCopyBufferToImage` with the destination offset/extent, transition back, `SubmitAndWait`.
- Contract: caller passes RGBA8 tightly packed; row pitch = `destRect.w() * 4`. Only supported on textures created via `AssetContext::TextureFromPixels` (i.e. CPU-writable ones). Caller is responsible for bounds — the rect must lie inside the texture.

## Motivation
Destructible-terrain consumers (and more generally, anything that keeps a CPU-side bitmap and mutates it at runtime) want to push only the dirty sub-rect each frame rather than recreating the whole texture. `TextureFromPixels` already produces streaming-capable textures on both backends; this just exposes the matching update path.

## Notes
- The Vulkan path uses `SubmitAndWait` to match the existing `FromRGBA` upload behaviour. That's fine for occasional updates (carve + cascade), but a future change could batch updates against the frame's command buffer for higher-frequency consumers.
- Vulkan format is `VK_FORMAT_R8G8B8A8_UNORM`, matching `FromRGBA`. SDL uses `SDL_PIXELFORMAT_RGBA32`, the endian-neutral packed RGBA8. Both agree on the byte layout the caller hands in.

## Test plan
- [ ] Build SDL + Vulkan; existing texture-using paths (image loading, font glyphs, sprites) still render correctly.
- [ ] Build a small consumer (or wait for scorched_moth terrain) that creates an empty texture via `TextureFromPixels`, then calls `UpdatePixels` with a sub-rect each frame; verify the sub-rect updates without affecting the rest of the image.
- [ ] Verify same visual on both backends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for updating pixel data within a sub-region of existing textures. This enables efficient partial texture updates without requiring full texture recreation, improving performance for dynamic texture modifications on textures created from pixel sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/instinkt900/moth_graphics/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->