### PR TITLE
feat: add IGraphics::DrawGradientRect for linear gradient fills

### DIFF
--- a/include/moth_graphics/graphics/igraphics.h
+++ b/include/moth_graphics/graphics/igraphics.h
@@ -79,6 +79,38 @@ namespace moth_graphics::graphics {
         /// @param rect Rectangle in logical pixels.
         virtual void DrawFillRectF(FloatRect const& rect) = 0;
 
+        /// @brief Draw a linear gradient inside @p destRect.
+        ///
+        /// The transition runs along an axis at @p angle radians, centred at
+        /// the midpoint (specified as a 0..1 factor of @p destRect), and lerps
+        /// from @p startColor to @p endColor over a length of
+        /// @p transitionLength × (the rect's projected extent along the
+        /// gradient axis). Outside the transition band, colour is clamped.
+        ///
+        /// **Clip:** this call does NOT manage the scissor. Geometry outside
+        /// @p destRect may be drawn unless the caller has set an appropriate
+        /// clip — typically via @c SetClip in moth_graphics, or
+        /// @c PushClip/PopClip when going through @c moth_ui::IRenderer.
+        ///
+        /// @param destRect          Destination rectangle in logical pixels.
+        /// @param startColor        Colour at the start side of the axis.
+        /// @param endColor          Colour at the end side of the axis.
+        /// @param midpoint          Normalised 0..1 location of the t=0.5
+        ///                          point inside @p destRect. (0.5, 0.5) =
+        ///                          centre of the rect.
+        /// @param angle             Direction of the gradient in radians;
+        ///                          0 = +x (towards endColor side), π/2 = +y.
+        /// @param transitionLength  Factor of the rect's projected extent
+        ///                          along the gradient axis. 1.0 = fills the
+        ///                          rect; 0.0 = sharp step at the midpoint;
+        ///                          values > 1 leave the lerp partially
+        ///                          outside the rect.
+        virtual void DrawGradientRect(FloatRect const& destRect,
+                                      Color startColor, Color endColor,
+                                      FloatVec2 midpoint,
+                                      float angle,
+                                      float transitionLength) = 0;
+
         /// @brief Draw a line segment using the current color.
         /// @param p0 Start point in logical pixels.
         /// @param p1 End point in logical pixels.

--- a/src/graphics/sdl/sdl_graphics.cpp
+++ b/src/graphics/sdl/sdl_graphics.cpp
@@ -171,6 +171,81 @@ namespace moth_graphics::graphics::sdl {
         SDL_RenderGeometry(m_surfaceContext.GetRenderer(), nullptr, sdlVertices, 6, nullptr, 0);
     }
 
+    void Graphics::DrawGradientRect(FloatRect const& destRect,
+                                    Color startColor, Color endColor,
+                                    FloatVec2 midpoint,
+                                    float angle,
+                                    float transitionLength) {
+        float const w = destRect.bottomRight.x - destRect.topLeft.x;
+        float const h = destRect.bottomRight.y - destRect.topLeft.y;
+        if (w <= 0.0f || h <= 0.0f) {
+            return;
+        }
+
+        // Pixel-space midpoint, gradient axis direction + perpendicular.
+        FloatVec2 const mp{
+            destRect.topLeft.x + (midpoint.x * w),
+            destRect.topLeft.y + (midpoint.y * h),
+        };
+        float const c = std::cos(angle);
+        float const s = std::sin(angle);
+        FloatVec2 const dir{ c, s };
+        FloatVec2 const perp{ -s, c };
+
+        // Rect's extent projected onto the gradient axis. This is what
+        // transitionLength is a factor of, so a value of 1.0 fills the rect
+        // along the axis for any angle.
+        float const projExtent = (std::abs(w * c) + std::abs(h * s));
+        float const transitionPixels = std::max(0.0f, transitionLength) * projExtent;
+        float const halfL = transitionPixels * 0.5f;
+
+        // Perpendicular extent large enough that the rotated band covers the
+        // entire dest rect regardless of angle. The scissor (set by the
+        // caller, or by moth_ui::IRenderer::RenderGradientRect) trims the
+        // visible portion to destRect.
+        float const cover = std::sqrt((w * w) + (h * h));
+
+        auto const t = CurrentTransform();
+        auto toWorld = [&](float lx, float ly) {
+            FloatVec2 const local{
+                mp.x + (dir.x * lx) + (perp.x * ly),
+                mp.y + (dir.y * lx) + (perp.y * ly),
+            };
+            return t.TransformPoint(local);
+        };
+
+        ColorComponents const startComp{ startColor };
+        ColorComponents const endComp{ endColor };
+        SDL_Color const sdlStart{ startComp.r, startComp.g, startComp.b, startComp.a };
+        SDL_Color const sdlEnd{ endComp.r, endComp.g, endComp.b, endComp.a };
+
+        auto submitQuad = [&](float x0, float x1, SDL_Color c0, SDL_Color c1) {
+            if (x0 >= x1) {
+                return;
+            }
+            auto const tl = toWorld(x0, -cover);
+            auto const tr = toWorld(x1, -cover);
+            auto const bl = toWorld(x0, +cover);
+            auto const br = toWorld(x1, +cover);
+            SDL_Vertex const verts[6] = {
+                { { tl.x, tl.y }, c0, { 0.0f, 0.0f } },
+                { { tr.x, tr.y }, c1, { 0.0f, 0.0f } },
+                { { bl.x, bl.y }, c0, { 0.0f, 0.0f } },
+                { { tr.x, tr.y }, c1, { 0.0f, 0.0f } },
+                { { br.x, br.y }, c1, { 0.0f, 0.0f } },
+                { { bl.x, bl.y }, c0, { 0.0f, 0.0f } },
+            };
+            SDL_RenderGeometry(m_surfaceContext.GetRenderer(), nullptr, verts, 6, nullptr, 0);
+        };
+
+        // Left flank (clamped to startColor) → transition band → right flank
+        // (clamped to endColor). If transitionPixels == 0 the middle is
+        // skipped and we get a sharp step where the two flanks meet.
+        submitQuad(-cover, -halfL, sdlStart, sdlStart);
+        submitQuad(-halfL, +halfL, sdlStart, sdlEnd);
+        submitQuad(+halfL, +cover, sdlEnd, sdlEnd);
+    }
+
     void Graphics::DrawLineF(FloatVec2 const& p0, FloatVec2 const& p1) {
         auto const t = CurrentTransform();
         auto const wp0 = t.TransformPoint(p0);

--- a/src/graphics/sdl/sdl_graphics.h
+++ b/src/graphics/sdl/sdl_graphics.h
@@ -39,6 +39,11 @@ namespace moth_graphics::graphics::sdl {
         void DrawImageTiled(Image const& image, IntRect const& destRect, IntRect const* sourceRect, float scale) override;
         void DrawRectF(FloatRect const& rect) override;
         void DrawFillRectF(FloatRect const& rect) override;
+        void DrawGradientRect(FloatRect const& destRect,
+                              Color startColor, Color endColor,
+                              FloatVec2 midpoint,
+                              float angle,
+                              float transitionLength) override;
         void DrawLineF(FloatVec2 const& p0, FloatVec2 const& p1) override;
         void DrawText(std::string_view text, IFont& font, IntRect const& destRect, TextHorizAlignment horizontalAlignment = TextHorizAlignment::Left, TextVertAlignment verticalAlignment = TextVertAlignment::Top) override;
         void SetClip(IntRect const* rect) override;

--- a/src/graphics/vulkan/vulkan_graphics.cpp
+++ b/src/graphics/vulkan/vulkan_graphics.cpp
@@ -284,6 +284,82 @@ namespace moth_graphics::graphics::vulkan {
         SubmitVertices(vertices, 6, ETopologyType::Triangles);
     }
 
+    void Graphics::DrawGradientRect(FloatRect const& destRect,
+                                    Color startColor, Color endColor,
+                                    FloatVec2 midpoint,
+                                    float angle,
+                                    float transitionLength) {
+        auto* context = CurrentContext();
+        if (context == nullptr) {
+            return;
+        }
+        float const w = destRect.bottomRight.x - destRect.topLeft.x;
+        float const h = destRect.bottomRight.y - destRect.topLeft.y;
+        if (w <= 0.0f || h <= 0.0f) {
+            return;
+        }
+
+        FloatVec2 const mp{
+            destRect.topLeft.x + (midpoint.x * w),
+            destRect.topLeft.y + (midpoint.y * h),
+        };
+        float const c = std::cos(angle);
+        float const s = std::sin(angle);
+        FloatVec2 const dir{ c, s };
+        FloatVec2 const perp{ -s, c };
+
+        float const projExtent = (std::abs(w * c) + std::abs(h * s));
+        float const transitionPixels = std::max(0.0f, transitionLength) * projExtent;
+        float const halfL = transitionPixels * 0.5f;
+
+        float const cover = std::sqrt((w * w) + (h * h));
+
+        auto const t = CurrentTransform();
+        auto toWorld = [&](float lx, float ly) {
+            FloatVec2 const local{
+                mp.x + (dir.x * lx) + (perp.x * ly),
+                mp.y + (dir.y * lx) + (perp.y * ly),
+            };
+            return t.TransformPoint(local);
+        };
+
+        auto submitQuad = [&](float x0, float x1, Color const& c0, Color const& c1) {
+            if (x0 >= x1) {
+                return;
+            }
+            auto const tl = toWorld(x0, -cover);
+            auto const tr = toWorld(x1, -cover);
+            auto const bl = toWorld(x0, +cover);
+            auto const br = toWorld(x1, +cover);
+
+            Vertex vertices[6];
+            vertices[0].xy = tl;
+            vertices[0].uv = { 0, 0 };
+            vertices[0].color = c0;
+            vertices[1].xy = tr;
+            vertices[1].uv = { 0, 0 };
+            vertices[1].color = c1;
+            vertices[2].xy = bl;
+            vertices[2].uv = { 0, 0 };
+            vertices[2].color = c0;
+            vertices[3].xy = bl;
+            vertices[3].uv = { 0, 0 };
+            vertices[3].color = c0;
+            vertices[4].xy = tr;
+            vertices[4].uv = { 0, 0 };
+            vertices[4].color = c1;
+            vertices[5].xy = br;
+            vertices[5].uv = { 0, 0 };
+            vertices[5].color = c1;
+
+            SubmitVertices(vertices, 6, ETopologyType::Triangles);
+        };
+
+        submitQuad(-cover, -halfL, startColor, startColor);
+        submitQuad(-halfL, +halfL, startColor, endColor);
+        submitQuad(+halfL, +cover, endColor, endColor);
+    }
+
     void Graphics::DrawLineF(FloatVec2 const& p0, FloatVec2 const& p1) {
         auto* context = CurrentContext();
         if (context == nullptr) {

--- a/src/graphics/vulkan/vulkan_graphics.h
+++ b/src/graphics/vulkan/vulkan_graphics.h
@@ -71,6 +71,11 @@ namespace moth_graphics::graphics::vulkan {
         void DrawImageTiled(Image const& image, IntRect const& destRect, IntRect const* sourceRect, float scale) override;
         void DrawRectF(FloatRect const& rect) override;
         void DrawFillRectF(FloatRect const& rect) override;
+        void DrawGradientRect(FloatRect const& destRect,
+                              Color startColor, Color endColor,
+                              FloatVec2 midpoint,
+                              float angle,
+                              float transitionLength) override;
         void DrawLineF(FloatVec2 const& p0, FloatVec2 const& p1) override;
         void DrawText(std::string_view text, IFont& font, IntRect const& destRect, TextHorizAlignment horizontalAlignment = TextHorizAlignment::Left, TextVertAlignment verticalAlignment = TextVertAlignment::Top) override;
         void SetClip(IntRect const* clipRect) override;


### PR DESCRIPTION
## Summary
Adds a primitive for drawing a linear gradient inside a rect. The transition is centred at a normalised midpoint inside the rect, runs along an axis at a caller-supplied angle, and lerps over a length expressed as a factor of the rect's projected extent along that axis. Outside the transition band, colour clamps to the start / end colour.

```cpp
virtual void DrawGradientRect(FloatRect const& destRect,
                              Color startColor, Color endColor,
                              FloatVec2 midpoint,           // normalised 0..1 of destRect
                              float angle,                  // radians
                              float transitionLength) = 0;  // factor of projected extent
```

## Geometry strategy
In a local space where the gradient axis is +x and the midpoint is at the origin, the rect is split into three quads:

```
       startColor          gradient            endColor
       (clamped)           (transition)        (clamped)
     ◄──────────►  ◄──────────────────────►  ◄──────────►
       cover            transitionPixels          cover
```

Each quad is then rotated by `angle` and translated to the midpoint to produce world-space vertices. Perpendicular extent (`cover`) is the rect's diagonal so the band fully covers the dest rect at any angle.

The `transitionLength × projectedExtent` formulation is what gives the API its scale-invariance — a gradient struct with normalised midpoint and factor-based length renders identically at any rect size or angle.

## Clipping
Caller is responsible. The rotated band can spill outside `destRect` at shallow angles, so callers should set a scissor first via `SetClip(&destRect)` or the moth_ui `PushClip` stack. The follow-up moth_ui PR will wrap `IRenderer::RenderGradientRect` in `PushClip` / `PopClip` automatically.

## Backend implementations
- **SDL**: three `SDL_RenderGeometry` calls with per-vertex `SDL_Color`.
- **Vulkan**: three `SubmitVertices` calls through the existing colour-aware vertex pipeline.

## Test plan
- [ ] Vertical gradient (angle=π/2, midpoint=(0.5,0.5), transitionLength=1.0) inside a 1280×720 rect spans top-to-bottom on both backends.
- [ ] Horizontal gradient (angle=0) spans left-to-right.
- [ ] 45° angled gradient on a square rect produces a corner-to-corner diagonal lerp; visible flank clamping when transitionLength < 1.
- [ ] transitionLength=0 produces a sharp two-colour split at the midpoint.
- [ ] transitionLength>1 leaves the band only partially visible inside the rect, with clamped flanks filling the rest.
- [ ] Caller-set clip via `SetClip(&destRect)` restricts visible output to the destRect; without clip, rotated band may extend beyond.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gradient rectangle rendering. Users can now draw angled linear gradients within rectangular areas with customizable colors, transition smoothness, and rotation parameters across all graphics rendering backends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/instinkt900/moth_graphics/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->